### PR TITLE
Small rpc fixes

### DIFF
--- a/examples/browser/bitcoin/ledger-send-transaction.html
+++ b/examples/browser/bitcoin/ledger-send-transaction.html
@@ -12,7 +12,8 @@
   <p><code>For errors and logs, check console</code></p>
   <script>
   /* global $, ChainAbstractionLayer */
-  const cal = new ChainAbstractionLayer(new ChainAbstractionLayer.providers.bitcoin.BitcoinLedgerProvider(true))
+  const cal = new ChainAbstractionLayer(new ChainAbstractionLayer.providers.bitcoin.BitcoinRPCProvider('http://localhost:8080', 'bitcoin', 'local321'))
+  cal.addProvider(new ChainAbstractionLayer.providers.bitcoin.BitcoinLedgerProvider(true))
   cal.getAddresses().then(addresses => {
     const from = addresses[0]
     $('#address').text(from)

--- a/src/providers/bitcoin/BitcoinRPCProvider.js
+++ b/src/providers/bitcoin/BitcoinRPCProvider.js
@@ -69,6 +69,6 @@ export default class BitcoinRPCProvider extends JsonRpcProvider {
   }
 
   async sendRawTransaction (rawTransaction) {
-    return this._rpc('sendrawtransaction', rawTransaction)
+    return this.rpc('sendrawtransaction', rawTransaction)
   }
 }

--- a/src/providers/ethereum/EthereumRPCProvider.js
+++ b/src/providers/ethereum/EthereumRPCProvider.js
@@ -19,11 +19,11 @@ export default class EthereumRPCProvider extends JsonRpcProvider {
   }
 
   async getBlockByNumber (blockNumber, includeTx) {
-    return this._rpc('eth_getBlockByNumber', blockNumber, includeTx)
+    return this.rpc('eth_getBlockByNumber', blockNumber, includeTx)
   }
 
   async getTransactionByHash (txHash) {
     txHash = ensureEthFormat(txHash)
-    return this._rpc('eth_getTransactionByHash', txHash)
+    return this.rpc('eth_getTransactionByHash', txHash)
   }
 }


### PR DESCRIPTION
This PR adds example `addProvider` on ledger `sendTransaction` implementation as well as fixes legacy `._rpc` calls to be `.rpc`.