### PR TITLE
Remove regenerator-runtime/runtime from lib and use babel-plugin-transform-runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -560,6 +560,45 @@
         "regenerator-transform": "^0.13.3"
       }
     },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.0.0-beta.56.tgz",
+      "integrity": "sha512-bzIp/hDJwvN0hiVMlkiwC43N74R49nO+syW2wql8L48Md2z9nfsS0zw3T96oCDBUgGXzOX8uKq9DUKZS9YktTA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "7.0.0-beta.56",
+        "@babel/helper-plugin-utils": "7.0.0-beta.56"
+      },
+      "dependencies": {
+        "@babel/helper-module-imports": {
+          "version": "7.0.0-beta.56",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.56.tgz",
+          "integrity": "sha512-iVWFscU+yIu6DIo5IWkMgVXd74/d3z/ZomwF/QJNGFwFP/lNA282rpjsky56fSxS7oT7wAlXoYoHVCOOaL7tbg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.56",
+            "lodash": "^4.17.10"
+          }
+        },
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0-beta.56",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.56.tgz",
+          "integrity": "sha512-6IlFMU13X7gwnnMldDHwfc7IqngqCH/KfiU7I+GdNoZPnddmjghc87E/zKHaJpWdX1VvXCCelp2EnKq0rgBQ8w==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.0.0-beta.56",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.56.tgz",
+          "integrity": "sha512-fRIBeHtKxAD3D1E7hYSpG4MnLt0AfzHHs5gfVclOB0NlfLu3qiWU/IqdbK2ixTK61424iEkV1P/VAzndx6ungA==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.10",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.0.0-beta.55",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-beta.55.tgz",
@@ -697,6 +736,14 @@
         "mkdirp": "^0.5.1",
         "pirates": "^4.0.0",
         "source-map-support": "^0.4.2"
+      }
+    },
+    "@babel/runtime": {
+      "version": "7.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.56.tgz",
+      "integrity": "sha512-vP9XV2VP013UEyZdU9eWClCsm6rQPUYHVNCfmpcv5uKviW7mKmUZq71Y5cr5dYsFKfnGDxSo8h6plUGR60lwHg==",
+      "requires": {
+        "regenerator-runtime": "^0.12.0"
       }
     },
     "@babel/template": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "publish:docs": "npm run build && npm run build:docs && gh-pages -d docs/ -m \"Auto-generated commit for documentation\""
   },
   "dependencies": {
+    "@babel/runtime": "^7.0.0-beta.56",
     "@ledgerhq/hw-app-btc": "^4.20.0",
     "@ledgerhq/hw-app-eth": "^4.19.0",
     "@ledgerhq/hw-transport-node-hid": "~4.21.0",
@@ -38,11 +39,11 @@
     "crypto-hashing": "^1.0.0",
     "json-bigint": "^0.3.0",
     "lodash": "^4.0.0",
-    "regenerator-runtime": "^0.12.0",
     "standard-error": "^1.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-beta.54",
+    "@babel/plugin-transform-runtime": "^7.0.0-beta.56",
     "@babel/polyfill": "^7.0.0-beta.54",
     "@babel/preset-env": "^7.0.0-beta.54",
     "@babel/register": "^7.0.0-beta.54",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
-import 'regenerator-runtime/runtime'
-
 import Client from './Client'
 import Provider from './Provider'
 

--- a/webpack.browser.config.js
+++ b/webpack.browser.config.js
@@ -48,7 +48,10 @@ module.exports = {
         exclude: /node_modules/,
         loader: 'babel-loader?cacheDirectory=true',
         options: {
-          plugins: [ 'lodash' ],
+          plugins: [
+            'lodash',
+            '@babel/plugin-transform-runtime'
+          ],
           presets: [
             [
               '@babel/preset-env', {

--- a/webpack.node.config.js
+++ b/webpack.node.config.js
@@ -33,6 +33,9 @@ module.exports = {
         exclude: /node_modules/,
         loader: 'babel-loader?cacheDirectory=true',
         options: {
+          plugins: [
+            '@babel/plugin-transform-runtime'
+          ],
           presets: [
             [
               '@babel/preset-env', {


### PR DESCRIPTION
Realised this when requiring it in `liquality-atomic-swap` repo. I should have done this earlier. Better late than never.

PS. Also, saves `11kb`.