### PR TITLE
Convert getAddresses to return object and add coinType

### DIFF
--- a/examples/browser/bitcoin/ledger-send-transaction.html
+++ b/examples/browser/bitcoin/ledger-send-transaction.html
@@ -15,7 +15,7 @@
   const { Client, providers, networks } = ChainAbstractionLayer
   const bitcoin = new Client()
   bitcoin.addProvider(new providers.bitcoin.BitcoinRPCProvider('http://localhost:8080', 'bitcoin', 'local321'))
-  bitcoin.addProvider(new providers.bitcoin.BitcoinLedgerProvider({ network: networks.testnet }))
+  bitcoin.addProvider(new providers.bitcoin.BitcoinLedgerProvider({ network: networks.bitcoin_testnet }))
   bitcoin.getAddresses().then(addresses => {
     const from = addresses[0]
     $('#address').text(from)

--- a/examples/browser/bitcoin/ledger-send-transaction.html
+++ b/examples/browser/bitcoin/ledger-send-transaction.html
@@ -15,7 +15,7 @@
   const { Client, providers } = ChainAbstractionLayer
   const bitcoin = new Client()
   bitcoin.addProvider(new providers.bitcoin.BitcoinRPCProvider('http://localhost:8080', 'bitcoin', 'local321'))
-  bitcoin.addProvider(new providers.bitcoin.BitcoinLedgerProvider(true))
+  bitcoin.addProvider(new providers.bitcoin.BitcoinLedgerProvider('testnet'))
   bitcoin.getAddresses().then(addresses => {
     const from = addresses[0]
     $('#address').text(from)

--- a/examples/browser/bitcoin/ledger-send-transaction.html
+++ b/examples/browser/bitcoin/ledger-send-transaction.html
@@ -12,10 +12,10 @@
   <p><code>For errors and logs, check console</code></p>
   <script>
   /* global $, ChainAbstractionLayer */
-  const { Client, providers } = ChainAbstractionLayer
+  const { Client, providers, networks } = ChainAbstractionLayer
   const bitcoin = new Client()
   bitcoin.addProvider(new providers.bitcoin.BitcoinRPCProvider('http://localhost:8080', 'bitcoin', 'local321'))
-  bitcoin.addProvider(new providers.bitcoin.BitcoinLedgerProvider('testnet'))
+  bitcoin.addProvider(new providers.bitcoin.BitcoinLedgerProvider({ network: networks.testnet }))
   bitcoin.getAddresses().then(addresses => {
     const from = addresses[0]
     $('#address').text(from)

--- a/examples/browser/bitcoin/ledger.html
+++ b/examples/browser/bitcoin/ledger.html
@@ -11,9 +11,9 @@
   <p><code>For errors and logs, check console</code></p>
   <script>
   /* global $, ChainAbstractionLayer */
-  const { Client, providers } = ChainAbstractionLayer
+  const { Client, providers, networks } = ChainAbstractionLayer
   const bitcoin = new Client()
-  bitcoin.addProvider(new providers.bitcoin.BitcoinLedgerProvider())
+  bitcoin.addProvider(new providers.bitcoin.BitcoinLedgerProvider({ network: networks.bitcoin }))
   bitcoin.getAddresses().then(addresses => {
     const from = addresses[0]
     $('#address').text(from)

--- a/src/Client.js
+++ b/src/Client.js
@@ -290,10 +290,10 @@ export default class Client {
    *  of accounts.
    *  Rejects with InvalidProviderResponseError if provider's response is invalid.
    */
-  async getAddresses () {
+  async getAddresses (segwit = false) {
     const provider = this.getProviderForMethod('getAddresses')
 
-    const addresses = await provider.getAddresses()
+    const addresses = await provider.getAddresses(segwit)
 
     if (!isArray(addresses)) {
       throw new InvalidProviderResponseError('Provider returned an invalid response')
@@ -366,8 +366,8 @@ export default class Client {
    */
   async generateSecret (message) {
     const addresses = await this.getAddresses()
-    const from = addresses[0]
-    const signedMessage = await this.signMessage(message, from)
+    const path = addresses[0].path
+    const signedMessage = await this.signMessage(message, path)
     const secret = hash160(signedMessage)
     return secret
   }

--- a/src/Client.js
+++ b/src/Client.js
@@ -364,9 +364,7 @@ export default class Client {
    * @param {!string} message - Message to be used for generating secret.
    * @return {Promise<string, null>} Resolves with a secret.
    */
-  async generateSecret (message) {
-    const addresses = await this.getAddresses()
-    const path = addresses[0].path
+  async generateSecret (message, path) {
     const signedMessage = await this.signMessage(message, path)
     const secret = hash160(signedMessage)
     return secret

--- a/src/Client.js
+++ b/src/Client.js
@@ -290,10 +290,10 @@ export default class Client {
    *  of accounts.
    *  Rejects with InvalidProviderResponseError if provider's response is invalid.
    */
-  async getAddresses (segwit = false) {
+  async getAddresses (config) {
     const provider = this.getProviderForMethod('getAddresses')
 
-    const addresses = await provider.getAddresses(segwit)
+    const addresses = await provider.getAddresses(config)
 
     if (!isArray(addresses)) {
       throw new InvalidProviderResponseError('Provider returned an invalid response')

--- a/src/Client.js
+++ b/src/Client.js
@@ -364,8 +364,8 @@ export default class Client {
    * @param {!string} message - Message to be used for generating secret.
    * @return {Promise<string, null>} Resolves with a secret.
    */
-  async generateSecret (message, path) {
-    const signedMessage = await this.signMessage(message, path)
+  async generateSecret (message) {
+    const signedMessage = await this.signMessage(message)
     const secret = hash160(signedMessage)
     return secret
   }

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import 'regenerator-runtime/runtime'
 
 import Client from './Client'
 import Provider from './Provider'
+import networks from './networks'
 
 import * as providers from './providers'
 import * as crypto from './crypto'
@@ -11,6 +12,7 @@ import * as schema from './schema'
 export {
   Client,
   Provider,
+  networks,
   providers,
   crypto,
   errors,

--- a/src/networks.js
+++ b/src/networks.js
@@ -5,7 +5,7 @@ export default {
     coinType: '0',
     explorerUrl: 'https://blockchain.info'
   },
-  testnet: {
+  bitcoin_testnet: {
     pubKeyHash: '6F',
     scriptHash: 'C4',
     coinType: '1',

--- a/src/networks.js
+++ b/src/networks.js
@@ -1,0 +1,25 @@
+export default {
+  bitcoin: {
+    pubKeyHash: '00',
+    scriptHash: '05',
+    coinType: '0',
+    explorerUrl: 'https://blockchain.info'
+  },
+  testnet: {
+    pubKeyHash: '6F',
+    scriptHash: 'C4',
+    coinType: '1',
+    explorerUrl: 'https://testnet.blockchain.info'
+  },
+  litecoin: {
+    pubKeyHash: '30',
+    scriptHash: '32',
+    coinType: '2'
+  },
+  ethereum: {
+    coinType: '60'
+  },
+  ethereum_classic: {
+    coinType: '61'
+  }
+}

--- a/src/providers/bitcoin/BitcoinLedgerProvider.js
+++ b/src/providers/bitcoin/BitcoinLedgerProvider.js
@@ -18,6 +18,7 @@ export default class BitcoinLedgerProvider extends Provider {
     this._ledgerBtc = false
     this._blockChainInfoBaseUrl = chain.network.explorerUrl
     this._coinType = chain.network.coinType
+    this._derivationPath = `44'/${this._coinType}'/0'/0/0`
   }
 
   async _connectToLedger () {
@@ -135,12 +136,12 @@ export default class BitcoinLedgerProvider extends Provider {
     return addresses
   }
 
-  async signMessage (message, path) {
+  async signMessage (message) {
     await this._connectToLedger()
 
     const hex = Buffer.from(message).toString('hex')
 
-    return this._ledgerBtc.signMessageNew(path, hex)
+    return this._ledgerBtc.signMessageNew(this._derivationPath, hex)
   }
 
   async sendTransaction (from, to, value, data) {

--- a/src/providers/bitcoin/BitcoinLedgerProvider.js
+++ b/src/providers/bitcoin/BitcoinLedgerProvider.js
@@ -40,8 +40,8 @@ export default class BitcoinLedgerProvider extends Provider {
     return (await axios.get(`${this._blockChainInfoBaseUrl}/rawtx/${transactionHash}?format=hex&cors=true`)).data
   }
 
-  async _getSpendingDetails (segwit = false) {
-    const purpose = segwit ? '49' : '44'
+  async _getSpendingDetails (config = { segwit: false }) {
+    const purpose = config.segwit ? '49' : '44'
     let unspentOutputs = []
     let unusedAddress
     let addressIndex = 0
@@ -49,7 +49,7 @@ export default class BitcoinLedgerProvider extends Provider {
     while (addressHasTransactions) {
       const path = `${purpose}'/${this._coinType}'/0'/0/${addressIndex}`
       const address = {
-        ...(await this._ledgerBtc.getWalletPublicKey(path, false, segwit)),
+        ...(await this._ledgerBtc.getWalletPublicKey(path, false, config.segwit)),
         path
       }
       const addressDetails = await this._getAddressDetails(address.bitcoinAddress)
@@ -122,11 +122,11 @@ export default class BitcoinLedgerProvider extends Provider {
     return buffer.reverse() // Amount needs to be little endian
   }
 
-  async getAddresses (segwit = false) {
+  async getAddresses (config = { segwit: false }) {
     await this._connectToLedger()
 
     let addresses = []
-    const { unusedAddress, unspentOutputs } = await this._getSpendingDetails(segwit)
+    const { unusedAddress, unspentOutputs } = await this._getSpendingDetails(config)
 
     const unspentAddresses = unspentOutputs.reduce((acc, detail) => (
       acc[acc.length - 1] === detail.address ? acc : acc.concat(detail.address)

--- a/src/providers/bitcoin/BitcoinLedgerProvider.js
+++ b/src/providers/bitcoin/BitcoinLedgerProvider.js
@@ -5,18 +5,19 @@ import Transport from '@alias/ledger-transport'
 import LedgerBtc from '@ledgerhq/hw-app-btc'
 import { BigNumber } from 'bignumber.js'
 
-import { addressToPubKeyHash, networks } from './BitcoinUtil'
+import { addressToPubKeyHash } from './BitcoinUtil'
+import networks from '../../networks'
 
 // TODO: Abstract out non signing methods into another provider?
 export default class BitcoinLedgerProvider extends Provider {
   /**
    * @param {boolean} testnet True if the testnet network is being used
    */
-  constructor (chain = 'bitcoin') {
+  constructor (chain = { network: networks.bitcoin }) {
     super()
     this._ledgerBtc = false
-    this._blockChainInfoBaseUrl = networks[chain].explorerUrl
-    this._coinType = networks[chain].coinType
+    this._blockChainInfoBaseUrl = chain.network.explorerUrl
+    this._coinType = chain.network.coinType
   }
 
   async _connectToLedger () {

--- a/src/providers/bitcoin/BitcoinUtil.js
+++ b/src/providers/bitcoin/BitcoinUtil.js
@@ -5,27 +5,6 @@ import {
   base58
 } from '../../crypto'
 
-export const networks = {
-  bitcoin: {
-    pubKeyHash: '00',
-    scriptHash: '05',
-    coinType: '0',
-    explorerUrl: 'https://blockchain.info'
-  },
-  testnet: {
-    pubKeyHash: '6F',
-    scriptHash: 'C4',
-    coinType: '1',
-    explorerUrl: 'https://testnet.blockchain.info'
-  },
-  litecoin: {
-    pubKeyHash: '30',
-    scriptHash: '32',
-    coinType: '2',
-    explorerUrl: 'https://blockchain.info'
-  }
-}
-
 /**
  * Get compressed pubKey from pubKey.
  * @param {!string} pubkey - 65 byte string with prefix, x, y.

--- a/src/providers/bitcoin/BitcoinUtil.js
+++ b/src/providers/bitcoin/BitcoinUtil.js
@@ -4,6 +4,7 @@ import {
   sha256,
   base58
 } from '../../crypto'
+import networks from '../../networks'
 
 /**
  * Get compressed pubKey from pubKey.
@@ -43,7 +44,7 @@ export function pubKeyToAddress (pubKey, network, type) {
 export function pubKeyHashToAddress (pubKeyHash, network, type) {
   pubKeyHash = ensureBuffer(pubKeyHash)
   const prefixHash = Buffer.concat([Buffer.from(networks[network][type], 'hex'), pubKeyHash])
-  const checksum = sha256(sha256(prefixHash)).slice(0, 4)
+  const checksum = Buffer.from(sha256(sha256(prefixHash)).slice(0, 4), 'hex')
   const addr = base58.encode(Buffer.concat([prefixHash, checksum]))
   return addr
 }

--- a/src/providers/bitcoin/BitcoinUtil.js
+++ b/src/providers/bitcoin/BitcoinUtil.js
@@ -5,18 +5,24 @@ import {
   base58
 } from '../../crypto'
 
-const networks = {
+export const networks = {
   bitcoin: {
     pubKeyHash: '00',
-    scriptHash: '05'
+    scriptHash: '05',
+    coinType: '0',
+    explorerUrl: 'https://blockchain.info'
   },
   testnet: {
     pubKeyHash: '6F',
-    scriptHash: 'C4'
+    scriptHash: 'C4',
+    coinType: '1',
+    explorerUrl: 'https://testnet.blockchain.info'
   },
   litecoin: {
     pubKeyHash: '30',
-    scriptHash: '32'
+    scriptHash: '32',
+    coinType: '2',
+    explorerUrl: 'https://blockchain.info'
   }
 }
 

--- a/src/providers/ethereum/EthereumLedgerProvider.js
+++ b/src/providers/ethereum/EthereumLedgerProvider.js
@@ -3,13 +3,13 @@ import Provider from '../../Provider'
 import Transport from '@alias/ledger-transport'
 import LedgerEth from '@ledgerhq/hw-app-eth'
 
-import { networks } from './EthereumUtil'
+import networks from '../../networks'
 
 export default class EthereumLedgerProvider extends Provider {
-  constructor (chain = 'ethereum') {
+  constructor (chain = { network: networks.ethereum }) {
     super()
     this._ledgerEth = false
-    this._coinType = networks[chain].coinType
+    this._coinType = chain.network.coinType
     this._derivationPath = `44'/${this._coinType}'/0'/0'/0`
   }
 

--- a/src/providers/ethereum/EthereumLedgerProvider.js
+++ b/src/providers/ethereum/EthereumLedgerProvider.js
@@ -32,11 +32,11 @@ export default class EthereumLedgerProvider extends Provider {
     return [ address ]
   }
 
-  async signMessage (message, path) {
+  async signMessage (message) {
     await this._connectToLedger()
 
     const hex = Buffer.from(message).toString('hex')
 
-    return this._ledgerEth.signPersonalMessage(path, hex)
+    return this._ledgerEth.signPersonalMessage(this._derivationPath, hex)
   }
 }

--- a/src/providers/ethereum/EthereumLedgerProvider.js
+++ b/src/providers/ethereum/EthereumLedgerProvider.js
@@ -3,11 +3,14 @@ import Provider from '../../Provider'
 import Transport from '@alias/ledger-transport'
 import LedgerEth from '@ledgerhq/hw-app-eth'
 
+import { networks } from './EthereumUtil'
+
 export default class EthereumLedgerProvider extends Provider {
-  constructor () {
+  constructor (chain = 'ethereum') {
     super()
     this._ledgerEth = false
-    this._derivationPath = `44'/60'/0'/0'/0`
+    this._coinType = networks[chain].coinType
+    this._derivationPath = `44'/${this._coinType}'/0'/0'/0`
   }
 
   async _connectToLedger () {
@@ -29,11 +32,11 @@ export default class EthereumLedgerProvider extends Provider {
     return [ address ]
   }
 
-  async signMessage (message) {
+  async signMessage (message, path) {
     await this._connectToLedger()
 
     const hex = Buffer.from(message).toString('hex')
 
-    return this._ledgerEth.signPersonalMessage(this._derivationPath, hex)
+    return this._ledgerEth.signPersonalMessage(path, hex)
   }
 }

--- a/src/providers/ethereum/EthereumMetaMaskProvider.js
+++ b/src/providers/ethereum/EthereumMetaMaskProvider.js
@@ -44,7 +44,7 @@ export default class EthereumMetaMaskProvider extends Provider {
     return this._toMM('eth_accounts')
   }
 
-  async signMessage (message, path) {
+  async signMessage (message) {
     const hex = Buffer.from(message).toString('hex')
     const addresses = await this.getAddresses()
     const from = addresses[0]

--- a/src/providers/ethereum/EthereumMetaMaskProvider.js
+++ b/src/providers/ethereum/EthereumMetaMaskProvider.js
@@ -44,8 +44,10 @@ export default class EthereumMetaMaskProvider extends Provider {
     return this._toMM('eth_accounts')
   }
 
-  async signMessage (message, from) {
+  async signMessage (message, path) {
     const hex = Buffer.from(message).toString('hex')
+    const addresses = await this.getAddresses()
+    const from = addresses[0]
 
     return this._toMM('personal_sign', `0x${hex}`, `0x${from}`)
   }

--- a/src/providers/ethereum/EthereumUtil.js
+++ b/src/providers/ethereum/EthereumUtil.js
@@ -1,5 +1,14 @@
 import { Block, Transaction } from '../../schema'
 
+export const networks = {
+  ethereum: {
+    coinType: '60'
+  },
+  ethereum_classic: {
+    coinType: '61'
+  }
+}
+
 export function formatEthResponse (obj) {
   if (Array.isArray(obj)) {
     obj = obj.map((elem) => {

--- a/src/providers/ethereum/EthereumUtil.js
+++ b/src/providers/ethereum/EthereumUtil.js
@@ -1,14 +1,5 @@
 import { Block, Transaction } from '../../schema'
 
-export const networks = {
-  ethereum: {
-    coinType: '60'
-  },
-  ethereum_classic: {
-    coinType: '61'
-  }
-}
-
 export function formatEthResponse (obj) {
   if (Array.isArray(obj)) {
     obj = obj.map((elem) => {


### PR DESCRIPTION
This PR adds global network config i.e. 

```
export default {
  bitcoin: {
    pubKeyHash: '00',
    scriptHash: '05',
    coinType: '0',
    explorerUrl: 'https://blockchain.info'
  },
  testnet: {
    pubKeyHash: '6F',
    scriptHash: 'C4',
    coinType: '1',
    explorerUrl: 'https://testnet.blockchain.info'
  },
  litecoin: {
    pubKeyHash: '30',
    scriptHash: '32',
    coinType: '2'
  },
  ethereum: {
    coinType: '60'
  },
  ethereum_classic: {
    coinType: '61'
  }
}

```

as well as segwit support for `getAddresses` with `coinType` specification (https://github.com/satoshilabs/slips/blob/master/slip-0044.md)