### PR TITLE
Fix sendtransaction btcledger

### DIFF
--- a/examples/browser/bitcoin/ledger-send-transaction.html
+++ b/examples/browser/bitcoin/ledger-send-transaction.html
@@ -5,27 +5,63 @@
 </head>
 <body>
   <h1>CAL + Ledger: Send transaction (Bitcoin)</h1>
+  <p>From: <span id="address"></span></p>
+  <p>Balance: <span id="balance"></span></p>
+  <p>New address: <span id="newAddress"></span></p>
+
+  <hr />
+  <h3>Pay to address</h3>
   <p>To: <input type="text" id="toAddress"/></p>
-  <p>Value: <input type="text" id="value" value="0"/></p>
-  <p><button id="send">Send</button></p>
+  <p>Value: <input type="text" id="addrValue" value="0"/></p>
+  <p><button id="sendAddr">Send</button></p>
+
+  <hr />
+  <h3>Pay to custom script</h3>
+  <p>Script: <input type="text" id="toScript"/></p>
+  <p>Value: <input type="text" id="scriptValue" value="0"/></p>
+  <p><button id="sendScript">Send</button></p>
+
+  <hr />
   <p>Result: <span id="result"></span></p>
   <p><code>For errors and logs, check console</code></p>
-  <script>
-  /* global $, ChainAbstractionLayer */
-  const { Client, providers, networks } = ChainAbstractionLayer
-  const bitcoin = new Client()
-  bitcoin.addProvider(new providers.bitcoin.BitcoinRPCProvider('http://localhost:8080', 'bitcoin', 'local321'))
-  bitcoin.addProvider(new providers.bitcoin.BitcoinLedgerProvider({ network: networks.bitcoin_testnet }))
-  bitcoin.getAddresses().then(addresses => {
-    const from = addresses[0]
-    $('#address').text(from)
 
-    $('#send').click(() => {
-      bitcoin.sendTransaction(from, $('#toAddress').val(), $('#value').val()).then(result => {
-        $('#result').text(JSON.stringify(result, null, 2))
+  <script>
+    /* global $, ChainAbstractionLayer */
+    const { Client, providers, networks } = ChainAbstractionLayer
+    const bitcoin = new Client()
+    bitcoin.addProvider(new providers.bitcoin.BitcoinRPCProvider('http://localhost:8080', 'bitcoin', 'local321'))
+    bitcoin.addProvider(new providers.bitcoin.BitcoinLedgerProvider({ network: networks.bitcoin_testnet }))
+
+    let addresses, balance, newAddresses
+    bitcoin.getUsedAddresses().then(usedAddrs => {
+      addresses = usedAddrs
+      $('#address').text(addresses.join(', '))
+
+      bitcoin.getBalance(addresses).then(blnce => {
+        balance = blnce
+        $('#balance').text(balance)
+      })
+
+      bitcoin.getUnusedAddresses().then(unusedAddrs => {
+        newAddresses = unusedAddrs
+        $('#newAddress').text(newAddresses[1])
+      })
+
+      $('#sendAddr').click(() => {
+        // pay to address:
+        // to, value
+        bitcoin.sendTransaction($('#toAddress').val(), parseInt($('#addrValue').val())).then(result => {
+          $('#result').text(JSON.stringify(result, null, 2))
+        })
+      })
+      $('#sendScript').click(() => {
+        // pay to script:
+        // null, value, script
+        bitcoin.sendTransaction(null, $('#scriptValue').val(), parseInt($('#toScript').val())).then(result => {
+          $('#result').text(JSON.stringify(result, null, 2))
+        })
       })
     })
-  })
   </script>
 </body>
 </html>

--- a/src/Client.js
+++ b/src/Client.js
@@ -388,19 +388,19 @@ export default class Client {
 
   /**
    * Send a transaction to the chain
-   * @param {!string} from - The address identifier for the sender.
-   * @param {!string} to - The address identifier for the receiver.
+   * @param {string} to - The address identifier for the receiver.
    * @param {!number} value - Number representing the amount associated with.
    *  the transaction.
    * @param {!string} [data] - Optional data to send with the transaction.
+   * @param {!string} [from] - Optional address identifier for the sender.
    * @return {Promise<string, InvalidProviderResponseError>} Resolves with an identifier for
    *  the broadcasted transaction.
    *  Rejects with InvalidProviderResponseError if provider's response is invalid.
    */
-  async sendTransaction (from, to, value, data) {
+  async sendTransaction (to, value, data, from) {
     const provider = this.getProviderForMethod('sendTransaction')
 
-    const txHash = await provider.sendTransaction(from, to, value, data)
+    const txHash = await provider.sendTransaction(to, value, data, from)
 
     if (!isString(txHash)) {
       throw new InvalidProviderResponseError('sendTransaction method should return a transaction id string')

--- a/src/Client.js
+++ b/src/Client.js
@@ -303,10 +303,6 @@ export default class Client {
       if (!addresses.every(isString)) {
         throw new TypeError('All addresses should be strings')
       }
-
-      if (!addresses.every(addr => (/^[A-Fa-f0-9]+$/.test(addr)))) {
-        throw new TypeError('All addresses should be valid hex strings')
-      }
     }
 
     const balance = await provider.getBalance(addresses)

--- a/src/networks.js
+++ b/src/networks.js
@@ -1,25 +1,30 @@
 export default {
   bitcoin: {
+    name: 'bitcoin',
     pubKeyHash: '00',
     scriptHash: '05',
     coinType: '0',
     explorerUrl: 'https://blockchain.info'
   },
   bitcoin_testnet: {
+    name: 'bitcoin_testnet',
     pubKeyHash: '6F',
     scriptHash: 'C4',
     coinType: '1',
     explorerUrl: 'https://testnet.blockchain.info'
   },
   litecoin: {
+    name: 'litecoin',
     pubKeyHash: '30',
     scriptHash: '32',
     coinType: '2'
   },
   ethereum: {
+    name: 'ethereum',
     coinType: '60'
   },
   ethereum_classic: {
+    name: 'ethereum_classic',
     coinType: '61'
   }
 }

--- a/src/providers/bitcoin/BitcoinLedgerProvider.js
+++ b/src/providers/bitcoin/BitcoinLedgerProvider.js
@@ -212,7 +212,7 @@ export default class BitcoinLedgerProvider extends Provider {
     let receivingAddress
     if (to == null) {
       const scriptPubKey = padHexStart(data)
-      receivingAddress = pubKeyToAddress(scriptPubKey, 'bitcoin', 'scriptHash') // TODO: add network and type here
+      receivingAddress = pubKeyToAddress(scriptPubKey, this._network.name, 'scriptHash')
     } else {
       receivingAddress = to
     }

--- a/src/providers/bitcoin/BitcoinUtil.js
+++ b/src/providers/bitcoin/BitcoinUtil.js
@@ -11,7 +11,7 @@ import networks from '../../networks'
  * @param {!string} pubkey - 65 byte string with prefix, x, y.
  * @return {string} Returns the compressed pubKey of uncompressed pubKey.
  */
-export function compressPubKey (pubKey) {
+function compressPubKey (pubKey) {
   const x = pubKey.substring(2, 66)
   const y = pubKey.substring(66, 130)
   let prefix
@@ -27,7 +27,7 @@ export function compressPubKey (pubKey) {
  * @param {!string} type - pubKeyHash or scriptHash.
  * @return {string} Returns the address of pubKey.
  */
-export function pubKeyToAddress (pubKey, network, type) {
+function pubKeyToAddress (pubKey, network, type) {
   pubKey = ensureBuffer(pubKey)
   const pubKeyHash = hash160(pubKey)
   const addr = this.pubKeyHashToAddress(pubKeyHash, network, type)
@@ -41,7 +41,7 @@ export function pubKeyToAddress (pubKey, network, type) {
  * @param {!string} type - pubKeyHash or scriptHash.
  * @return {string} Returns the address derived from pubKeyHash.
  */
-export function pubKeyHashToAddress (pubKeyHash, network, type) {
+function pubKeyHashToAddress (pubKeyHash, network, type) {
   pubKeyHash = ensureBuffer(pubKeyHash)
   const prefixHash = Buffer.concat([Buffer.from(networks[network][type], 'hex'), pubKeyHash])
   const checksum = Buffer.from(sha256(sha256(prefixHash)).slice(0, 4), 'hex')
@@ -54,6 +54,13 @@ export function pubKeyHashToAddress (pubKeyHash, network, type) {
  * @param {!string} address - bitcoin base58 encoded address.
  * @return {string} Returns the pubKeyHash of bitcoin address.
  */
-export function addressToPubKeyHash (address) {
+function addressToPubKeyHash (address) {
   return base58.decode(address).toString('hex').substring(2, 42)
+}
+
+export {
+  compressPubKey,
+  pubKeyToAddress,
+  pubKeyHashToAddress,
+  addressToPubKeyHash
 }

--- a/src/providers/ethereum/EthereumMetaMaskProvider.js
+++ b/src/providers/ethereum/EthereumMetaMaskProvider.js
@@ -53,7 +53,7 @@ export default class EthereumMetaMaskProvider extends Provider {
     return this._toMM('personal_sign', `0x${hex}`, `0x${from}`)
   }
 
-  async sendTransaction (from, to, value, data) {
+  async sendTransaction (to, value, data, from) {
     value = BigNumber(value).toString(16)
 
     const tx = {


### PR DESCRIPTION
### Description

Quick fix for sendTransaction in BitcoinLedgerProvider.
First merge #48 and #49 

### Parts

- [x] Generalized `to` field in btc, allows for both p2pkh and p2sh through a helper function called `_generateScript`
- [x] Modified order of arguments for sendTransaction
- [x] Removed the fake promise of sending to multiple parties in bitcoin
- [x] Added examples in examples/browser/bitcoin/ledger-send-transaction.html