### PR TITLE
GetBalance on Ethereum

### DIFF
--- a/src/providers/ethereum/EthereumRPCProvider.js
+++ b/src/providers/ethereum/EthereumRPCProvider.js
@@ -31,5 +31,6 @@ export default class EthereumRPCProvider extends JsonRpcProvider {
     const addrs = addresses.map(ensureEthFormat)
     const promiseBalances = await Promise.all(addrs.map(address => this.rpc('eth_getBalance', address, 'latest')))
     return promiseBalances.map(balance => parseInt(balance, 16))
+      .reduce((acc, balance) => acc + balance, 0)
   }
 }

--- a/src/providers/ethereum/EthereumRPCProvider.js
+++ b/src/providers/ethereum/EthereumRPCProvider.js
@@ -1,5 +1,4 @@
 import JsonRpcProvider from '../JsonRpcProvider'
-import { padHexStart } from '../../crypto'
 
 import { formatEthResponse, ensureEthFormat } from './EthereumUtil'
 
@@ -31,9 +30,6 @@ export default class EthereumRPCProvider extends JsonRpcProvider {
   async getBalance (addresses) {
     const addrs = addresses.map(ensureEthFormat)
     const promiseBalances = await Promise.all(addrs.map(address => this.rpc('eth_getBalance', address, 'latest')))
-    return promiseBalances
-      .map(balance => balance.replace('0x', ''))
-      .map(padHexStart)
-      .map(balance => parseInt(balance, 16))
+    return promiseBalances.map(balance => parseInt(balance, 16))
   }
 }

--- a/src/providers/ethereum/EthereumRPCProvider.js
+++ b/src/providers/ethereum/EthereumRPCProvider.js
@@ -1,4 +1,5 @@
 import JsonRpcProvider from '../JsonRpcProvider'
+import { padHexStart } from '../../crypto'
 
 import { formatEthResponse, ensureEthFormat } from './EthereumUtil'
 
@@ -25,5 +26,14 @@ export default class EthereumRPCProvider extends JsonRpcProvider {
   async getTransactionByHash (txHash) {
     txHash = ensureEthFormat(txHash)
     return this.rpc('eth_getTransactionByHash', txHash)
+  }
+
+  async getBalance (addresses) {
+    const addrs = addresses.map(ensureEthFormat)
+    const promiseBalances = await Promise.all(addrs.map(address => this.rpc('eth_getBalance', address, 'latest')))
+    return promiseBalances
+      .map(balance => balance.replace('0x', ''))
+      .map(padHexStart)
+      .map(balance => parseInt(balance, 16))
   }
 }


### PR DESCRIPTION
### Description

Implement `getBalance` following #49 's documentation.
That is, the function takes in a list of addresses and gives a cumulative balance of all addresses.

### Parts

- [x] Add getBalance to RPC provider
- [ ] Add getBalance to MetaMask provider
