### PR TITLE
Add Bitcoin ledger provider split transaction segwit setting

### DIFF
--- a/src/providers/bitcoin/BitcoinLedgerProvider.js
+++ b/src/providers/bitcoin/BitcoinLedgerProvider.js
@@ -115,7 +115,7 @@ export default class BitcoinLedgerProvider extends Provider {
   async _getLedgerInputs (unspentOutputs) {
     const ledgerInputs = unspentOutputs.map(async utxo => {
       const transactionHex = await this._getTransactionHex(utxo.tx_hash_big_endian)
-      const tx = await this._ledgerBtc.splitTransaction(transactionHex)
+      const tx = await this._ledgerBtc.splitTransaction(transactionHex, true)
       return [tx, utxo.tx_output_n]
     })
     return Promise.all(ledgerInputs)


### PR DESCRIPTION
### Description

When first implementing Ledger Inputs we intended to allow for swaps with non segwit transaction. However we didn't account for the possibility of funding legacy addresses with segwit transactions. Therefore, certain transaction splitting would result in ridiculous values being incorrectly calculated for `amount` and `script`. This PR fixes that. 

### Submission Checklist :pencil:

- [x] isSegwitSupported: true 
