### PR TITLE
Swap: add startBlock parameter to find functions

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -372,10 +372,11 @@ export default class Client {
    * @param {!string} refundAddress - Refund address
    * @param {!string} secretHash - Secret hash
    * @param {!string} expiration - Expiration time
+   * @param {number} [startBlock] - The block number to start finding from (Optional)
    * @return {Promise<string>} Resolves with a transaction identifier.
    */
-  async findInitiateSwapTransaction (value, recipientAddress, refundAddress, secretHash, expiration) {
-    return this.getMethod('findInitiateSwapTransaction')(value, recipientAddress, refundAddress, secretHash, expiration)
+  async findInitiateSwapTransaction (value, recipientAddress, refundAddress, secretHash, expiration, startBlock = null) {
+    return this.getMethod('findInitiateSwapTransaction')(value, recipientAddress, refundAddress, secretHash, expiration, startBlock)
   }
 
   /**
@@ -385,10 +386,11 @@ export default class Client {
    * @param {!string} refundAddress - Refund address
    * @param {!string} secretHash - Secret hash
    * @param {!string} expiration - Expiration time
+   * @param {number} [startBlock] - The block number to start finding from (Optional)
    * @return {Promise<string>} Resolves with a transaction identifier.
    */
-  async findClaimSwapTransaction (initiationTxHash, recipientAddress, refundAddress, secretHash, expiration) {
-    return this.getMethod('findClaimSwapTransaction')(initiationTxHash, recipientAddress, refundAddress, secretHash, expiration)
+  async findClaimSwapTransaction (initiationTxHash, recipientAddress, refundAddress, secretHash, expiration, startBlock = null) {
+    return this.getMethod('findClaimSwapTransaction')(initiationTxHash, recipientAddress, refundAddress, secretHash, expiration, startBlock)
   }
 
   /**

--- a/src/providers/ethereum/EthereumSwapProvider.js
+++ b/src/providers/ethereum/EthereumSwapProvider.js
@@ -103,8 +103,8 @@ export default class EthereumSwapProvider extends Provider {
     return transactionMatchesSwapParams && initiationTransactionReceipt.status === '1'
   }
 
-  async findInitiateSwapTransaction (value, recipientAddress, refundAddress, secretHash, expiration) {
-    let blockNumber = await this.getMethod('getBlockHeight')()
+  async findInitiateSwapTransaction (value, recipientAddress, refundAddress, secretHash, expiration, startBlock) {
+    let blockNumber = startBlock || await this.getMethod('getBlockHeight')()
     let initiateSwapTransaction = null
     while (!initiateSwapTransaction) {
       const block = await this.getMethod('getBlockByNumber')(blockNumber, true)
@@ -119,8 +119,8 @@ export default class EthereumSwapProvider extends Provider {
     return initiateSwapTransaction
   }
 
-  async findClaimSwapTransaction (initiationTxHash) {
-    let blockNumber = await this.getMethod('getBlockHeight')()
+  async findClaimSwapTransaction (initiationTxHash, recipientAddress, refundAddress, secretHash, expiration, startBlock) {
+    let blockNumber = startBlock || await this.getMethod('getBlockHeight')()
     let claimSwapTransaction = null
     while (!claimSwapTransaction) {
       const initiationTransaction = await this.getMethod('getTransactionReceipt')(initiationTxHash)


### PR DESCRIPTION
The `startBlock` parameter for the find functions will allow us to within reasonable time find any swap transaction when we know which block it was initiated at. 
This is important for when we don't have the transactions or looking for arbitary swaps. 