### PR TITLE
Fix webusb interface not supported issue

### DIFF
--- a/src/providers/LedgerProvider.js
+++ b/src/providers/LedgerProvider.js
@@ -1,4 +1,4 @@
-import Transport from '@ledgerhq/hw-transport-node-hid'
+import Transport from "@ledgerhq/hw-transport-u2f";
 import WalletProvider from './WalletProvider'
 import { WalletError } from '../errors'
 


### PR DESCRIPTION
### Description

This PR reverts ledger transport provider to u2f. Recently have been getting the following error `The interface number provided is not supported by the device in its current configuration.`

<img width="810" alt="Screen Shot 2019-03-31 at 9 43 54 PM" src="https://user-images.githubusercontent.com/5362629/55298959-9d750000-53fe-11e9-9901-6bcf504ef749.png">

### Submission Checklist :pencil:

- [x] Change transport to u2f for `LedgerProvider`