### PR TITLE
Add generate secrets fn

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -1,5 +1,6 @@
 import { find, findLast, findLastIndex, isArray, isBoolean, isFunction, isNumber, isString } from 'lodash'
 import Ajv from 'ajv'
+import BigNumber from 'bignumber.js'
 
 import { Block, Transaction } from './schema'
 import { sha256 } from './crypto'
@@ -404,6 +405,24 @@ export default class Client {
     const signedMessage = await this.signMessage(message, address)
     const secret = sha256(signedMessage)
     return secret
+  }
+
+  /**
+   * Generate secrets.
+   * @param {!string} message - Message to be used for generating secret.
+   * @param {!string} address - can pass address for async claim and refunds to get deterministic secrets
+   * @return {Promise<string>} Resolves with a 32 byte secret
+   */
+  async generateSecrets (message, num = 1) {
+    const address = (await this.getMethod('getAddresses')())[0].address
+    const signedMessage = await this.signMessage(message, address)
+    let secrets = []
+
+    for (let i = 0; i < num; i++) {
+      secrets.push(sha256(BigNumber(signedMessage, 16).plus(i).toString(16)))
+    }
+
+    return secrets
   }
 
   /**

--- a/src/Client.js
+++ b/src/Client.js
@@ -415,15 +415,17 @@ export default class Client {
    */
   async generateSecrets (message, num = 1) {
     const address = (await this.getMethod('getAddresses')())[0].address
-    const signedMessage = await this.signMessage(message, address)
+    let secretMessage = await this.signMessage(message, address)
     let secrets = []
 
     for (let i = 0; i < num; i++) {
-      secrets.push(sha256(BigNumber(signedMessage, 16).plus(i).toString(16)))
+      secretMessage = sha256(Buffer.from(secretMessage, 'hex').reverse().toString('hex'))
+      secrets.push(sha256(secretMessage))
     }
 
     return secrets
   }
+
 
   /**
    * Get secret from claim transaction hash.


### PR DESCRIPTION
### Description

This PR adds the function `generateSecrets` to `Client.js`. This allows a user to sign a single message, and generate as many secrets as they want safely and deterministically, by simply incrementing the hash returned from signing and hashing that to get the secret. 

This is a much better user experience for cross-chain applications that require generating multiple secrets. 

### Submission Checklist :pencil:

- [x] Add `generateSecrets` fn to `Client.js`
