### PR TITLE
Add getConnectedNetwork to Client.js

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -529,6 +529,10 @@ export default class Client {
     return this.getMethod('getWalletInfo')()
   }
 
+  async getConnectedNetwork () {
+    return this.getMethod('getConnectedNetwork')()
+  }
+
   async getAddressMempool (addresses) {
     return this.getMethod('getAddressMempool')(addresses)
   }


### PR DESCRIPTION
### Description

This PR exposes the `getConnectedNetwork` fn in `Client.js` since it is useful for implementing connect wallets that show the network the user is connected to. For example: 

<img width="338" alt="Screen Shot 2019-04-07 at 6 36 48 PM" src="https://user-images.githubusercontent.com/5362629/55690800-20004100-5964-11e9-9ad6-ac9985a6cd3a.png">

`getConnectedNetwork` is already implemented in `BitcoinLedgerProvider.js`, `EthereumMetaMaskProvider.js`. 

### Submission Checklist :pencil:

- [x] Add `getConnectedNetwork` fn in `Client.js`
