### PR TITLE
Add find fns for collateral provider

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -568,4 +568,12 @@ export default class Client {
   async multisigSendCollateral (refundableTxHash, seizableTxHash, borrowerPubKey, lenderPubKey, secretHashA1, secretA2, secretHashB2, secretB3, loanExpiration, biddingExpiration, seizureExpiration, borrowerSignatures, lenderSignatures, to) {
     return this.getMethod('multisigSendCollateral')(refundableTxHash, seizableTxHash, borrowerPubKey, lenderPubKey, secretHashA1, secretA2, secretHashB2, secretB3, loanExpiration, biddingExpiration, seizureExpiration, borrowerSignatures, lenderSignatures, to)
   }
+
+  async findLockRefundableCollateralTransaction (refundableValue, seizableValue, borrowerPubKey, lenderPubKey, secretHashA1, secretHashA2, secretHashB2, secretHashB3, loanExpiration, biddingExpiration, seizureExpiration) {
+    return this.getMethod('findLockRefundableCollateralTransaction')(refundableValue, seizableValue, borrowerPubKey, lenderPubKey, secretHashA1, secretHashA2, secretHashB2, secretHashB3, loanExpiration, biddingExpiration, seizureExpiration)
+  }
+
+  async findLockSeizableCollateralTransaction (refundableValue, seizableValue, borrowerPubKey, lenderPubKey, secretHashA1, secretHashA2, secretHashB2, secretHashB3, loanExpiration, biddingExpiration, seizureExpiration) {
+    return this.getMethod('findLockSeizableCollateralTransaction')(refundableValue, seizableValue, borrowerPubKey, lenderPubKey, secretHashA1, secretHashA2, secretHashB2, secretHashB3, loanExpiration, biddingExpiration, seizureExpiration)
+  }
 }


### PR DESCRIPTION
### Description

This PR adds the necessary functions to enable `findLockRefundableCollateralTransaction` and `findLockSeizableCollateralTransaction` fns in order to easily find a bitcoin collateral refundable and seizable transaction. 

### Submission Checklist :pencil:

- [x] Add `doesTransactionMatchRefundableCollateralParams` function
- [x] Add `doesTransactionMatchSeizableCollateralParams` function
- [x] Add `verifyLockRefundableCollateralTransaction` function
- [x] Add `verifyLockSeizableCollateralTransaction` function
- [x] Add `findRefundableCollateralTransaction` function
- [x] Add `findSeizableCollateralTransaction` function
- [x] Add `findLockRefundableCollateralTransaction` function
- [x] Add `findLockSeizableCollateralTransaction` function
- [x] Add necessary functions to `Client.js`