### PR TITLE
EthereumLedgerProvider: add gas estimation

### DIFF
--- a/src/providers/ethereum/EthereumRPCProvider.js
+++ b/src/providers/ethereum/EthereumRPCProvider.js
@@ -101,6 +101,11 @@ export default class EthereumRPCProvider extends JsonRpcProvider {
       .reduce((acc, balance) => acc.plus(balance), new BigNumber(0))
   }
 
+  async estimateGas (transaction) {
+    const estimatedGas = await this.jsonrpc('eth_estimateGas', transaction)
+    return parseInt(estimatedGas, '16')
+  }
+
   async isAddressUsed (address) {
     address = ensureHexEthFormat(String(address))
 


### PR DESCRIPTION
### Description

FIXES https://github.com/liquality/chainabstractionlayer/issues/161
Adds gas estimation for transactions sent from the Ledger provider.

### Submission Checklist :pencil:

- [x] Add `estimateGas` function to EthereumRPCProvider
- [x] Modify EthereumLedgerProvider to use gas estimation when building transaction
