### PR TITLE
Add additional ethereum utils

### DIFF
--- a/packages/ethereum-utils/lib/index.js
+++ b/packages/ethereum-utils/lib/index.js
@@ -1,4 +1,6 @@
 import { Block, Transaction } from '@liquality/schema'
+import { padHexStart } from '@liquality/crypto'
+import eip55 from 'eip55'
 
 import { version } from '../package.json'
 
@@ -18,6 +20,26 @@ function ensure0x (hash) {
  */
 function remove0x (hash) {
   return (typeof hash === 'string') ? hash.replace(/^0x/, '') : hash
+}
+
+/**
+ * Converts an ethereum address to the standard format
+ * @param {*} address
+ */
+function removeAddress0x (address) {
+  return remove0x(address).toLowerCase()
+}
+
+function checksumEncode (hash) {
+  return eip55.encode(ensure0x(hash))
+}
+
+function ensureBlockFormat (block) {
+  if (block === undefined) {
+    return 'latest'
+  } else {
+    return (typeof(block) === 'number') ? ensure0x(padHexStart(block.toString(16))) : block
+  }
 }
 
 function formatEthResponse (obj) {
@@ -66,6 +88,8 @@ function normalizeTransactionObject (tx, currentHeight) {
 export {
   ensure0x,
   remove0x,
+  removeAddress0x,
+  checksumEncode,
   formatEthResponse,
   normalizeTransactionObject,
 

--- a/packages/ethereum-utils/package-lock.json
+++ b/packages/ethereum-utils/package-lock.json
@@ -12,10 +12,57 @@
 				"regenerator-runtime": "^0.13.2"
 			}
 		},
+		"bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"requires": {
+				"file-uri-to-path": "1.0.0"
+			}
+		},
+		"eip55": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/eip55/-/eip55-1.0.3.tgz",
+			"integrity": "sha512-x1p4OJNlt0G3mPPZx9GgwOaLFvz8Wd4VFpkx3iNzW4SrakFnjjO4mDdmAJpETxJZp9SlNB4UFqDuFhElnX9K/Q==",
+			"requires": {
+				"keccak": "1.4.0"
+			}
+		},
+		"file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+		},
+		"keccak": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+			"integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+			"requires": {
+				"bindings": "1.5.0",
+				"inherits": "2.0.3",
+				"nan": "2.14.0",
+				"safe-buffer": "5.1.2"
+			}
+		},
+		"nan": {
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+			"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+		},
 		"regenerator-runtime": {
 			"version": "0.13.2",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
 			"integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+		},
+		"safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		}
 	}
 }

--- a/packages/ethereum-utils/package.json
+++ b/packages/ethereum-utils/package.json
@@ -18,7 +18,9 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.4.3",
-    "@liquality/schema": "^0.2.7"
+    "@liquality/crypto": "^0.2.7",
+    "@liquality/schema": "^0.2.7",
+    "eip55": "^1.0.3"
   },
   "engines": {
     "node": "~8.12.0"


### PR DESCRIPTION
### Description

Add `removeAddress0x`, `checksumEncode` and `ensureBlockFormat` to Ethereum utils

`removeAddress0x` is for standardizing an Ethereum address and converting it to lower case

`checksumEncode` is for ensuring that an Ethereum address is following EIP 55

`ensureBlockFormat` is for ensuring that block parameter specified is using the correct format, when using calls such as `eth_call` (https://infura.io/docs/ethereum/json-rpc/eth_call). 

For example, you could have `client.chains.getCode(contractAddress, 'latest')` or  `client.chains.getCode(contractAddress, 7896092)` or even not include it, and it would ensure that it defaulted to `latest`. 

### Submission Checklist :pencil:

- [x] Add `removeAddress0x`
- [x] Add `checksumEncode`
- [x] Add `ensureBlockFormat`
