### PR TITLE
Add sendBatchTransaction to BitcoinRpcProvider

### DIFF
--- a/packages/bitcoin-rpc-provider/lib/BitcoinRpcProvider.js
+++ b/packages/bitcoin-rpc-provider/lib/BitcoinRpcProvider.js
@@ -46,6 +46,17 @@ export default class BitcoinRpcProvider extends JsonRpcProvider {
     return this.jsonrpc('sendtoaddress', to, value)
   }
 
+  async sendBatchTransaction (transactions) {
+    let outputs = {}
+    for (const tx of transactions) {
+      outputs[addressToString(tx.to)] = BigNumber(tx.value).dividedBy(1e8).toNumber()
+    }
+    const rawTxOutputs = await this.createRawTransaction([], outputs)
+    const rawTxFunded = await this.fundRawTransaction(rawTxOutputs)
+    const rawTxSigned = await this.signRawTransaction(rawTxFunded.hex)
+    return this.sendRawTransaction(rawTxSigned.hex)
+  }
+
   async dumpPrivKey (address) {
     address = addressToString(address)
     return this.jsonrpc('dumpprivkey', address)
@@ -57,6 +68,10 @@ export default class BitcoinRpcProvider extends JsonRpcProvider {
 
   async createRawTransaction (transactions, outputs) {
     return this.jsonrpc('createrawtransaction', transactions, outputs)
+  }
+
+  async fundRawTransaction (hexstring) {
+    return this.jsonrpc('fundrawtransaction', hexstring)
   }
 
   async isAddressUsed (address) {

--- a/test/integration/tx/transactions.js
+++ b/test/integration/tx/transactions.js
@@ -56,4 +56,8 @@ describe('Send Batch Transactions', function () {
   describe('Bitcoin - Ledger', () => {
     testBatchTransaction(chains.bitcoinWithLedger)
   })
+
+  describe('Bitcoin - Ledger', () => {
+    testBatchTransaction(chains.bitcoinWithNode)
+  })
 })


### PR DESCRIPTION
### Description

Similar to https://github.com/liquality/chainabstractionlayer/pull/187 this PR adds `sentBatchTransaction` to `BitcoinRpcProvider `allowing you to specify multiple outputs for a Bitcoin transaction for a Node. 

For example: sendBatchTransaction ([{ to: address1, value: value1, data: script1 }, { to: address2, value: value2, data: script2 }]) 

### Submission Checklist :pencil:

- [x] Add `sendBatchTransaction` to `BitcoinRpcProvider`
- [x] Add test for `sendBatchTransaction` in `test/integration/tx/transactions.js`
