### PR TITLE
Implement EthereumJsWalletProvider

### DIFF
--- a/packages/bundle/lib/providers.js
+++ b/packages/bundle/lib/providers.js
@@ -11,6 +11,7 @@ import EthereumErc20Provider from '@liquality/ethereum-erc20-provider'
 import EthereumErc20SwapProvider from '@liquality/ethereum-erc20-swap-provider'
 import EthereumLedgerProvider from '@liquality/ethereum-ledger-provider'
 import EthereumMetaMaskProvider from '@liquality/ethereum-metamask-provider'
+import EthereumJsWalletProvider from '@liquality/ethereum-js-wallet-provider'
 import EthereumRpcProvider from '@liquality/ethereum-rpc-provider'
 import EthereumSwapProvider from '@liquality/ethereum-swap-provider'
 import * as EthereumNetworks from '@liquality/ethereum-networks'
@@ -33,6 +34,7 @@ const ethereum = {
   EthereumErc20SwapProvider,
   EthereumLedgerProvider,
   EthereumMetaMaskProvider,
+  EthereumJsWalletProvider,
   EthereumRpcProvider,
   EthereumSwapProvider,
   EthereumNetworks,

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -34,6 +34,7 @@
     "@liquality/ethereum-erc20-swap-provider": "^0.3.2",
     "@liquality/ethereum-ledger-provider": "^0.3.2",
     "@liquality/ethereum-metamask-provider": "^0.3.2",
+    "@liquality/ethereum-js-wallet-provider": "^0.3.2",
     "@liquality/ethereum-networks": "^0.3.2",
     "@liquality/ethereum-rpc-provider": "^0.3.2",
     "@liquality/ethereum-swap-provider": "^0.3.2",

--- a/packages/ethereum-js-wallet-provider/README.md
+++ b/packages/ethereum-js-wallet-provider/README.md
@@ -1,0 +1,11 @@
+# `@liquality/ethereum-js-wallet-provider`
+
+> TODO: description
+
+## Usage
+
+```
+const ethereumJsWalletProvider = require('@liquality/ethereum-js-wallet-provider');
+
+// TODO: DEMONSTRATE API
+```

--- a/packages/ethereum-js-wallet-provider/lib/EthereumJsWalletProvider.js
+++ b/packages/ethereum-js-wallet-provider/lib/EthereumJsWalletProvider.js
@@ -1,0 +1,103 @@
+import Provider from '@liquality/provider'
+import { Address, addressToString } from '@liquality/utils'
+import { ensure0x, remove0x } from '@liquality/ethereum-utils'
+import { sha256 } from '@liquality/crypto'
+import { mnemonicToSeed } from 'bip39'
+import { BigNumber } from 'bignumber.js'
+import { fromMasterSeed } from 'hdkey'
+import * as ethUtil from 'ethereumjs-util'
+import { Transaction } from 'ethereumjs-tx'
+
+import { version } from '../package.json'
+
+export default class EthereumJsWalletProvider extends Provider {
+  constructor (network, mnemonic) {
+    super()
+    const derivationPath = `m/44'/${network.coinType}'/0'/`
+    this._derivationPath = derivationPath
+    this._mnemonic = mnemonic
+    this._network = network
+  }
+
+  async node () {
+    const seed = await mnemonicToSeed(this._mnemonic)
+    return fromMasterSeed(seed)
+  }
+
+  async hdKey (derivationPath) {
+    const node = await this.node()
+    return node.derive(derivationPath)
+  }
+
+  async signMessage (message) {
+    const derivationPath = this._derivationPath + '0/0'
+    const hdKey = await this.hdKey(derivationPath)
+    const msgHash = sha256(message)
+    const hex = Buffer.from(msgHash, 'hex')
+
+    const { v, r, s } = ethUtil.ecsign(hex, hdKey._privateKey)
+
+    return { v, r: r.toString('hex'), s: s.toString('hex') }
+  }
+
+  async getAddresses () {
+    const derivationPath = this._derivationPath + '0/0'
+    const hdKey = await this.hdKey(derivationPath)
+    const address = ethUtil.privateToAddress(hdKey._privateKey).toString('hex')
+    const publicKey = ethUtil.privateToPublic(hdKey._privateKey).toString('hex')
+    return [
+      new Address({
+        address,
+        derivationPath,
+        publicKey,
+        index: 0
+      })
+    ]
+  }
+
+  async getUnusedAddress () {
+    const addresses = await this.getAddresses()
+    return addresses[0]
+  }
+
+  async getUsedAddresses () {
+    return this.getAddresses()
+  }
+
+  async sendTransaction (to, value, data) {
+    const derivationPath = this._derivationPath + '0/0'
+    const hdKey = await this.hdKey(derivationPath)
+
+    const addresses = await this.getAddresses()
+    const address = addresses[0]
+    const from = addressToString(address)
+
+    const txData = {
+      to: to ? ensure0x(to) : null,
+      from: ensure0x(from),
+      value: ensure0x(BigNumber(value).toString(16)),
+      data: data ? ensure0x(data) : undefined,
+      chainId: ensure0x(BigNumber(this._network.chainId).toString(16))
+    }
+
+    const [ nonce, gasPrice, gasLimit ] = await Promise.all([
+      this.getMethod('getTransactionCount')(remove0x(from)),
+      this.getMethod('getGasPrice')(),
+      this.getMethod('estimateGas')(txData)
+    ])
+
+    txData.nonce = nonce
+    txData.gasPrice = gasPrice
+    txData.gasLimit = gasLimit
+
+    const tx = new Transaction(txData)
+    tx.sign(hdKey._privateKey)
+    const serializedTx = tx.serialize().toString('hex')
+
+    const txHash = this.getMethod('sendRawTransaction')(serializedTx)
+
+    return txHash
+  }
+}
+
+EthereumJsWalletProvider.version = version

--- a/packages/ethereum-js-wallet-provider/lib/index.js
+++ b/packages/ethereum-js-wallet-provider/lib/index.js
@@ -1,0 +1,3 @@
+import EthereumJsWalletProvider from './EthereumJsWalletProvider'
+
+export default EthereumJsWalletProvider

--- a/packages/ethereum-js-wallet-provider/package-lock.json
+++ b/packages/ethereum-js-wallet-provider/package-lock.json
@@ -1,0 +1,586 @@
+{
+  "name": "@liquality/ethereum-js-wallet-provider",
+  "version": "0.3.2",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/runtime": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.3.tgz",
+      "integrity": "sha512-9lsJwJLxDh/T3Q3SZszfWOTkk3pHbkmH+3KY+zwIDmsNlxsumuhS2TH3NIpktU4kNvfzy+k3eLT7aTJSPTo0OA==",
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
+    "@liquality/crypto": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@liquality/crypto/-/crypto-0.3.2.tgz",
+      "integrity": "sha512-TpfAeCPuCyywDuZ9WNwefhD/R0AWEo82zupdKnqiU2JHcPP/z8Cc8dT8iuMIYF34u/a2WguF91tG76VP9YNbwg==",
+      "requires": {
+        "@babel/runtime": "^7.4.3",
+        "bech32": "^1.1.3",
+        "bs58": "^4.0.1",
+        "crypto-hashing": "^1.0.0"
+      }
+    },
+    "@liquality/ethereum-utils": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@liquality/ethereum-utils/-/ethereum-utils-0.3.2.tgz",
+      "integrity": "sha512-m1FvFhyuaO+mYOSin3u9PTRV7bhSMhgfUX5rcA1J71EIvfbablNf7u2P19/CSXyfV9/NSezPdUblGhWxTh9ydw==",
+      "requires": {
+        "@babel/runtime": "^7.4.3",
+        "@liquality/crypto": "^0.3.2",
+        "@liquality/schema": "^0.3.2",
+        "eip55": "^1.0.3"
+      }
+    },
+    "@liquality/provider": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@liquality/provider/-/provider-0.3.2.tgz",
+      "integrity": "sha512-Ob93VzkgWcT+gK5SHPgx2cxXbre3ex8ZMvdvtKvkn41UIcqpjh690533qbMlju3Hr2QJ//5QZ4KzhMzABiz6Pg==",
+      "requires": {
+        "@babel/runtime": "^7.4.3"
+      }
+    },
+    "@liquality/schema": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@liquality/schema/-/schema-0.3.2.tgz",
+      "integrity": "sha512-S3Ge8b1/HuTyoUCIXn4NSkfHmj/XdroNR4Zjcy1xPmc8A9QRqS4WPdN8vxJWLNc8ligt5L3E4+U8UdsS4hY3Hw==",
+      "requires": {
+        "@babel/runtime": "^7.4.3"
+      }
+    },
+    "@liquality/utils": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@liquality/utils/-/utils-0.3.2.tgz",
+      "integrity": "sha512-0Fn02F1L1HRuCQjjEo+U6oOqyKv9vKsK+p28VUMmeThVfdBY8CBKh2lsc6F9M+Kqcy0sMJI90E7IgznA8DdbqQ==",
+      "requires": {
+        "@babel/runtime": "^7.4.3"
+      }
+    },
+    "@types/node": {
+      "version": "10.12.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
+      "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
+    },
+    "base-x": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.6.tgz",
+      "integrity": "sha512-4PaF8u2+AlViJxRVjurkLTxpp7CaFRD/jo5rPT9ONnKxyhQ8f59yzamEvq7EkriG56yn5On4ONyaG75HLqr46w==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "bech32": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.3.tgz",
+      "integrity": "sha512-yuVFUvrNcoJi0sv5phmqc6P+Fl1HjRDRNOOkHY2X/3LBy2bIGNSFx4fZ95HMaXHupuS7cZR15AsvtmCIF4UEyg=="
+    },
+    "bignumber.js": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bip174": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bip174/-/bip174-1.0.1.tgz",
+      "integrity": "sha512-Mq2aFs1TdMfxBpYPg7uzjhsiXbAtoVq44TNjEWtvuZBiBgc3m7+n55orYMtTAxdg7jWbL4DtH0MKocJER4xERQ=="
+    },
+    "bip32": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/bip32/-/bip32-2.0.4.tgz",
+      "integrity": "sha512-ioPytarPDIrWckWMuK4RNUtvwhvWEc2fvuhnO0WEwu732k5OLjUXv4rXi2c/KJHw9ZMNQMkYRJrBw81RujShGQ==",
+      "requires": {
+        "@types/node": "10.12.18",
+        "bs58check": "^2.1.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "tiny-secp256k1": "^1.1.0",
+        "typeforce": "^1.11.5",
+        "wif": "^2.0.6"
+      }
+    },
+    "bip39": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.2.tgz",
+      "integrity": "sha512-J4E1r2N0tUylTKt07ibXvhpT2c5pyAFgvuA5q1H9uDy6dEGpjV8jmymh3MTYJDLCNbIVClSB9FbND49I6N24MQ==",
+      "requires": {
+        "@types/node": "11.11.6",
+        "create-hash": "^1.1.0",
+        "pbkdf2": "^3.0.9",
+        "randombytes": "^2.0.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "11.11.6",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
+          "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
+        }
+      }
+    },
+    "bip66": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+      "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "bitcoin-ops": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz",
+      "integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow=="
+    },
+    "bitcoinjs-lib": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-5.1.5.tgz",
+      "integrity": "sha512-VAcdXH7cNocWwEF2dAVTozOZtDHB+FVZH9tc9OLbUKzRLiYxb3C5lvAzBmd1QJR3CtPRJELgw049MvM5fs2dow==",
+      "requires": {
+        "@types/node": "10.12.18",
+        "bech32": "^1.1.2",
+        "bip174": "^1.0.1",
+        "bip32": "^2.0.4",
+        "bip66": "^1.1.0",
+        "bitcoin-ops": "^1.4.0",
+        "bs58check": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.3",
+        "merkle-lib": "^2.0.10",
+        "pushdata-bitcoin": "^1.0.1",
+        "randombytes": "^2.0.1",
+        "tiny-secp256k1": "^1.1.1",
+        "typeforce": "^1.11.3",
+        "varuint-bitcoin": "^1.0.4",
+        "wif": "^2.0.1"
+      }
+    },
+    "bitcoinjs-message": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-message/-/bitcoinjs-message-2.1.0.tgz",
+      "integrity": "sha512-xVL2YvyAJUI8ZwfNpi6Ju5zda3+QYGHTLUvISDb0VHWbsWn9Zyvd1o8XHRC/0r+DNwDIwenpXDSPl1XLCMGnMA==",
+      "requires": {
+        "bech32": "^1.1.3",
+        "bs58check": "^2.1.2",
+        "buffer-equals": "^1.0.3",
+        "create-hash": "^1.1.2",
+        "secp256k1": "^3.0.1",
+        "varuint-bitcoin": "^1.0.1"
+      }
+    },
+    "bn.js": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+    },
+    "brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
+    "browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "requires": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+      "requires": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "requires": {
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "buffer-equals": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/buffer-equals/-/buffer-equals-1.0.4.tgz",
+      "integrity": "sha1-A1O1T9B/2VZBcGca5vZrnPENJ/U="
+    },
+    "buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+    },
+    "cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "coinselect": {
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/coinselect/-/coinselect-3.1.11.tgz",
+      "integrity": "sha1-4fBjvRpYgvZzXuBRm52LWsSpMJk="
+    },
+    "coinstring": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/coinstring/-/coinstring-2.3.0.tgz",
+      "integrity": "sha1-zbYzY6lhUCQEolr7gsLibV/2J6Q=",
+      "requires": {
+        "bs58": "^2.0.1",
+        "create-hash": "^1.1.1"
+      },
+      "dependencies": {
+        "bs58": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/bs58/-/bs58-2.0.1.tgz",
+          "integrity": "sha1-VZCNWPGYKrogCPob7Y+RmYopv40="
+        }
+      }
+    },
+    "create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "requires": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
+    "crypto-hashing": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-hashing/-/crypto-hashing-1.0.0.tgz",
+      "integrity": "sha1-MOFnNxkUMJVToevrHL5nU7DIjKo=",
+      "requires": {
+        "create-hash": "^1.1.2"
+      }
+    },
+    "drbg.js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
+      "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
+      "requires": {
+        "browserify-aes": "^1.0.6",
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4"
+      }
+    },
+    "eip55": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/eip55/-/eip55-1.0.3.tgz",
+      "integrity": "sha512-x1p4OJNlt0G3mPPZx9GgwOaLFvz8Wd4VFpkx3iNzW4SrakFnjjO4mDdmAJpETxJZp9SlNB4UFqDuFhElnX9K/Q==",
+      "requires": {
+        "keccak": "^1.3.0"
+      }
+    },
+    "elliptic": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
+      "integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
+      "requires": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
+      }
+    },
+    "ethereumjs-common": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.3.1.tgz",
+      "integrity": "sha512-kexqNgM2q29RKoZPPjehPREeqbr/vhYfT9Ho8FVeH3f7USjBuYp1iZ1qjqklk8FSMvEKPpMJFYSOunikw30Prw=="
+    },
+    "ethereumjs-tx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.1.tgz",
+      "integrity": "sha512-QtVriNqowCFA19X9BCRPMgdVNJ0/gMBS91TQb1DfrhsbR748g4STwxZptFAwfqehMyrF8rDwB23w87PQwru0wA==",
+      "requires": {
+        "ethereumjs-common": "^1.3.1",
+        "ethereumjs-util": "^6.0.0"
+      }
+    },
+    "ethereumjs-util": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
+      "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
+      "requires": {
+        "bn.js": "^4.11.0",
+        "create-hash": "^1.1.2",
+        "ethjs-util": "0.1.6",
+        "keccak": "^1.0.2",
+        "rlp": "^2.0.0",
+        "safe-buffer": "^5.1.1",
+        "secp256k1": "^3.0.1"
+      }
+    },
+    "ethjs-util": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
+      "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
+      "requires": {
+        "is-hex-prefixed": "1.0.0",
+        "strip-hex-prefix": "1.0.0"
+      }
+    },
+    "evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "requires": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
+    "hash-base": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "hdkey": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hdkey/-/hdkey-1.1.1.tgz",
+      "integrity": "sha512-DvHZ5OuavsfWs5yfVJZestsnc3wzPvLWNk6c2nRUfo6X+OtxypGt20vDDf7Ba+MJzjL3KS1og2nw2eBbLCOUTA==",
+      "requires": {
+        "coinstring": "^2.0.0",
+        "safe-buffer": "^5.1.1",
+        "secp256k1": "^3.0.1"
+      }
+    },
+    "hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "requires": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "is-hex-prefixed": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
+      "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
+    },
+    "keccak": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+      "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+      "requires": {
+        "bindings": "^1.2.1",
+        "inherits": "^2.0.3",
+        "nan": "^2.2.1",
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "merkle-lib": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/merkle-lib/-/merkle-lib-2.0.10.tgz",
+      "integrity": "sha1-grjbrnXieneFOItz+ddyXQ9vMyY="
+    },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
+    "minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+    },
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+    },
+    "pbkdf2": {
+      "version": "3.0.17",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
+      "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+      "requires": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
+    "pushdata-bitcoin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz",
+      "integrity": "sha1-FZMdPNlnreUiBvUjqnMxrvfUOvc=",
+      "requires": {
+        "bitcoin-ops": "^1.3.0"
+      }
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+    },
+    "ripemd160": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      }
+    },
+    "rlp": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.3.tgz",
+      "integrity": "sha512-l6YVrI7+d2vpW6D6rS05x2Xrmq8oW7v3pieZOJKBEdjuTF4Kz/iwk55Zyh1Zaz+KOB2kC8+2jZlp2u9L4tTzCQ==",
+      "requires": {
+        "bn.js": "^4.11.1",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+    },
+    "secp256k1": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
+      "integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
+      "requires": {
+        "bindings": "^1.5.0",
+        "bip66": "^1.1.5",
+        "bn.js": "^4.11.8",
+        "create-hash": "^1.2.0",
+        "drbg.js": "^1.0.1",
+        "elliptic": "^6.4.1",
+        "nan": "^2.14.0",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "strip-hex-prefix": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
+      "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
+      "requires": {
+        "is-hex-prefixed": "1.0.0"
+      }
+    },
+    "tiny-secp256k1": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.3.tgz",
+      "integrity": "sha512-ZpobrhOtHP98VYEN51IYQH1YcrbFpnxFhI6ceWa3OEbJn7eHvSd8YFjGPxbedGCy7PNYU1v/+BRsdvyr5uRd4g==",
+      "requires": {
+        "bindings": "^1.3.0",
+        "bn.js": "^4.11.8",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.4.0",
+        "nan": "^2.13.2"
+      }
+    },
+    "typeforce": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
+      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
+    },
+    "varuint-bitcoin": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz",
+      "integrity": "sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==",
+      "requires": {
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "wif": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
+      "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
+      "requires": {
+        "bs58check": "<3.0.0"
+      }
+    }
+  }
+}

--- a/packages/ethereum-js-wallet-provider/package.json
+++ b/packages/ethereum-js-wallet-provider/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@liquality/ethereum-js-wallet-provider",
+  "umdName": "EthereumJsWalletProvider",
+  "umdExport": "default",
+  "version": "0.3.2",
+  "description": "",
+  "module": "lib/index.js",
+  "main": "dist/index.cjs.js",
+  "files": [
+    "dist",
+    "lib"
+  ],
+  "scripts": {
+    "build:node": "webpack --config ../../webpack/webpack.node.config.js",
+    "build:browser": "webpack --config ../../webpack/webpack.browser.config.js",
+    "build": "webpack --config ../../webpack/webpack.config.js"
+  },
+  "author": "Liquality <info@liquality.io>",
+  "license": "MIT",
+  "dependencies": {
+    "@babel/runtime": "^7.4.3",
+    "@liquality/crypto": "^0.3.2",
+    "@liquality/ethereum-utils": "^0.3.2",
+    "@liquality/provider": "^0.3.2",
+    "@liquality/utils": "^0.3.2",
+    "bignumber.js": "^9.0.0",
+    "bip39": "^3.0.2",
+    "bitcoinjs-lib": "^5.1.5",
+    "bitcoinjs-message": "^2.1.0",
+    "coinselect": "^3.1.11",
+    "ethereumjs-tx": "^2.1.1",
+    "ethereumjs-util": "^6.1.0",
+    "hdkey": "^1.1.1"
+  },
+  "engines": {
+    "node": "~8.12.0"
+  },
+  "homepage": "https://github.com/liquality/chainabstractionlayer#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/liquality/chainabstractionlayer.git"
+  },
+  "bugs": {
+    "url": "https://github.com/liquality/chainabstractionlayer/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "gitHead": "1855d9ec369c8c577f74eb04e310a7c00b9eaa6c"
+}

--- a/packages/ethereum-networks/lib/index.js
+++ b/packages/ethereum-networks/lib/index.js
@@ -43,6 +43,11 @@ export default {
     chainId: 5,
     isTestnet: true
   },
+  local: {
+    name: 'local',
+    coinType: '60',
+    isTestnet: true
+  },
 
   version
 }

--- a/test/integration/common.js
+++ b/test/integration/common.js
@@ -40,10 +40,11 @@ class RandomEthereumAddressProvider extends Provider {
 }
 
 const ethereumNetworks = providers.ethereum.networks
+const ethereumNetwork = ethereumNetworks[config.ethereum.network]
 
 const ethereumWithMetaMask = new Client()
 ethereumWithMetaMask.addProvider(new providers.ethereum.EthereumRpcProvider(config.ethereum.rpc.host))
-ethereumWithMetaMask.addProvider(new providers.ethereum.EthereumMetaMaskProvider(metaMaskConnector.getProvider(), ethereumNetworks[config.ethereum.network]))
+ethereumWithMetaMask.addProvider(new providers.ethereum.EthereumMetaMaskProvider(metaMaskConnector.getProvider(), ethereumNetwork))
 ethereumWithMetaMask.addProvider(new providers.ethereum.EthereumSwapProvider())
 ethereumWithMetaMask.addProvider(new RandomEthereumAddressProvider())
 
@@ -58,9 +59,15 @@ ethereumWithLedger.addProvider(new providers.ethereum.EthereumLedgerProvider())
 ethereumWithLedger.addProvider(new providers.ethereum.EthereumSwapProvider())
 ethereumWithLedger.addProvider(new RandomEthereumAddressProvider())
 
+const ethereumWithJs = new Client()
+ethereumWithJs.addProvider(new providers.ethereum.EthereumRpcProvider(config.ethereum.rpc.host))
+ethereumWithJs.addProvider(new providers.ethereum.EthereumJsWalletProvider(ethereumNetwork, generateMnemonic(256)))
+ethereumWithJs.addProvider(new providers.ethereum.EthereumSwapProvider())
+ethereumWithJs.addProvider(new RandomEthereumAddressProvider())
+
 const erc20WithMetaMask = new Client()
 erc20WithMetaMask.addProvider(new providers.ethereum.EthereumRpcProvider(config.ethereum.rpc.host))
-erc20WithMetaMask.addProvider(new providers.ethereum.EthereumMetaMaskProvider(metaMaskConnector.getProvider(), ethereumNetworks[config.ethereum.network]))
+erc20WithMetaMask.addProvider(new providers.ethereum.EthereumMetaMaskProvider(metaMaskConnector.getProvider(), ethereumNetwork))
 erc20WithMetaMask.addProvider(new providers.ethereum.EthereumErc20Provider('We dont have an addres yet'))
 erc20WithMetaMask.addProvider(new providers.ethereum.EthereumErc20SwapProvider())
 erc20WithMetaMask.addProvider(new RandomEthereumAddressProvider())
@@ -85,6 +92,7 @@ const chains = {
   ethereumWithMetaMask: { id: 'Ethereum MetaMask', name: 'ethereum', client: ethereumWithMetaMask },
   ethereumWithNode: { id: 'Ethereum Node', name: 'ethereum', client: ethereumWithNode },
   ethereumWithLedger: { id: 'Ethereum Ledger', name: 'ethereum', client: ethereumWithLedger },
+  ethereumWithJs: { id: 'Ethereum Js', name: 'ethereum', client: ethereumWithJs },
   erc20WithMetaMask: { id: 'ERC20 MetaMask', name: 'ethereum', client: erc20WithMetaMask },
   erc20WithNode: { id: 'ERC20 Node', name: 'ethereum', client: erc20WithNode },
   erc20WithLedger: { id: 'Erc20 Ledger', name: 'ethereum', client: erc20WithLedger }
@@ -128,6 +136,11 @@ async function fundUnusedBitcoinAddress (chain) {
   const unusedAddress = await chain.client.wallet.getUnusedAddress()
   await chains.bitcoinWithNode.client.chain.sendTransaction(unusedAddress, 100000000)
   await chains.bitcoinWithNode.client.chain.generateBlock(1)
+}
+
+async function fundUnusedEthereumAddress (chain) {
+  const unusedAddress = await chain.client.wallet.getUnusedAddress()
+  await chains.ethereumWithNode.client.chain.sendTransaction(unusedAddress, (10 ** 18))
 }
 
 async function initiateAndVerify (chain, secretHash, swapParams) {
@@ -213,6 +226,7 @@ export {
   chains,
   importBitcoinAddresses,
   fundUnusedBitcoinAddress,
+  fundUnusedEthereumAddress,
   metaMaskConnector,
   initiateAndVerify,
   claimAndVerify,

--- a/test/integration/config.js
+++ b/test/integration/config.js
@@ -14,6 +14,7 @@ export default {
       host: 'http://localhost:8545'
     },
     value: 10000000000000000,
+    network: 'local',
     metaMaskConnector: {
       port: 3333
     }

--- a/test/integration/wallet/ethereumJsWallet.js
+++ b/test/integration/wallet/ethereumJsWallet.js
@@ -1,0 +1,82 @@
+/* eslint-env mocha */
+/* eslint-disable no-unused-expressions */
+import chai, { expect } from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import { chains, fundUnusedEthereumAddress } from '../common'
+import config from '../config'
+
+process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = 0
+
+chai.use(chaiAsPromised)
+chai.use(require('chai-bignumber')())
+
+function testWallet (chain) {
+  describe('getAddresses', () => {
+    it('should return first address at index 0 derivationPath', async () => {
+      const expectedAddress0DerivationPath = `m/44'/60'/0'/0/0`
+      const addresses = await chain.client.wallet.getAddresses()
+
+      expect(addresses.length).to.equal(1)
+      expect(addresses[0].derivationPath).to.equal(expectedAddress0DerivationPath)
+    })
+  })
+
+  describe('getUnusedAddress', () => {
+    it('should return first address at index 0 derivationPath', async () => {
+      const expectedAddress0DerivationPath = `m/44'/60'/0'/0/0`
+      const address = await chain.client.wallet.getUnusedAddress()
+
+      expect(address.derivationPath).to.equal(expectedAddress0DerivationPath)
+    })
+  })
+
+  describe('getUsedAddresses', () => {
+    it('should return first address at index 0 derivationPath', async () => {
+      const expectedAddress0DerivationPath = `m/44'/60'/0'/0/0`
+      const addresses = await chain.client.wallet.getUsedAddresses()
+
+      expect(addresses.length).to.equal(1)
+      expect(addresses[0].derivationPath).to.equal(expectedAddress0DerivationPath)
+    })
+  })
+
+  describe('signMessage', () => {
+    it('should return v, r, s with v as a number, and r, s as hex', async () => {
+      const addresses = await chain.client.wallet.getAddresses()
+      const { address } = addresses[0]
+
+      const { v, r, s } = await chain.client.wallet.signMessage('secret', address)
+
+      const rBuffer = Buffer.from(r, 'hex')
+      const sBuffer = Buffer.from(s, 'hex')
+
+      expect(Number.isInteger(v)).to.equal(true)
+      expect(r).to.equal(rBuffer.toString('hex'))
+      expect(s).to.equal(sBuffer.toString('hex'))
+    })
+
+    it('should return the same v, r, s values if signed twice', async () => {
+      const addresses = await chain.client.wallet.getAddresses()
+      const { address } = addresses[0]
+
+      const { v: v1, r: r1, s: s1 } = await chain.client.wallet.signMessage('secret', address)
+      const { v: v2, r: r2, s: s2 } = await chain.client.wallet.signMessage('secret', address)
+
+      expect(v1).to.equal(v2)
+      expect(r1).to.equal(r2)
+      expect(s1).to.equal(s2)
+    })
+  })
+}
+
+describe('Wallet Interaction', function () {
+  this.timeout(config.timeout)
+
+  describe('Ethereum - Js', () => {
+    beforeEach(async function () {
+      await fundUnusedEthereumAddress(chains.ethereumWithJs)
+    })
+
+    testWallet(chains.ethereumWithJs)
+  })
+})


### PR DESCRIPTION
### Description

This PR implements `EthereumJsWalletProvider`. It allows you to provide a 12 - 24 word mnemonic to the provider, and uses a similar derivation scheme as Ledger Nano. 

### Submission Checklist :pencil:

- [x] Implement `EthereumJsWalletProvider`
- [x] Add tests for `EthereumJsWalletProvider` 
