### PR TITLE
Fixes #202 invalidating correct difficulty in regtest node

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "lint": "standard $npm_package_options_standard",
     "bootstrap": "lerna bootstrap --force-local",
     "test": "cross-env NODE_ENV=test nyc mocha packages/*/test/unit $npm_package_options_mocha",
+    "test:chain": "cross-env NODE_ENV=test nyc mocha test/integration/chain $npm_package_options_mocha",
     "test:swap": "cross-env NODE_ENV=test nyc mocha test/integration/swap $npm_package_options_mocha",
     "test:tx": "cross-env NODE_ENV=test nyc mocha test/integration/tx $npm_package_options_mocha",
     "test:wallet": "cross-env NODE_ENV=test nyc mocha test/integration/wallet $npm_package_options_mocha",

--- a/packages/bitcoin-rpc-provider/lib/BitcoinRpcProvider.js
+++ b/packages/bitcoin-rpc-provider/lib/BitcoinRpcProvider.js
@@ -106,7 +106,7 @@ export default class BitcoinRpcProvider extends JsonRpcProvider {
       hash,
       number,
       timestamp,
-      difficulty,
+      difficulty: parseFloat(BigNumber(difficulty).toFixed()),
       size,
       parentHash,
       nonce,

--- a/packages/bitcoin-rpc-provider/test/unit/index.test.js
+++ b/packages/bitcoin-rpc-provider/test/unit/index.test.js
@@ -105,7 +105,7 @@ describe('Bitcoin RPC provider', () => {
         hash: '191c4a31dc689cd02c3c3858838db5b4b07f8fe5af0fad61c5ea0dfb7163f254',
         number: 102,
         timestamp: 1544536091,
-        difficulty: '4.656542373906925e-10',
+        difficulty: 4.656542373906925e-10,
         size: 371,
         parentHash: '432e14437b326efe9ea90031729eb0713d19445b077ab442a98e6a48dde0da44',
         nonce: 1,

--- a/test/integration/chain/chain.js
+++ b/test/integration/chain/chain.js
@@ -1,0 +1,29 @@
+/* eslint-env mocha */
+/* eslint-disable no-unused-expressions */
+import chai, { expect } from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import { chains } from '../common'
+import config from '../config'
+
+process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = 0
+
+chai.use(chaiAsPromised)
+chai.use(require('chai-bignumber')())
+
+function testGetBlock (chain) {
+  it('Should validate block correct and return block height as number', async () => {
+    const blockHeight = await chain.client.chain.getBlockHeight()
+    const block = await chain.client.chain.getBlockByNumber(blockHeight)
+
+    expect(blockHeight).to.equal(parseInt(blockHeight))
+    expect(block.number).to.equal(blockHeight)
+  })
+}
+
+describe('Send Transactions', function () {
+  this.timeout(config.timeout)
+
+  describe('Bitcoin - Ledger', () => {
+    testGetBlock(chains.bitcoinWithNode)
+  })
+})


### PR DESCRIPTION
### Description

This PR fixes https://github.com/liquality/chainabstractionlayer/issues/202 which causes blocks with difficulty as an exponential number to be invalidated. 

For example, the following block would be invalid because difficulty is `4.656542373906925e-10` which is an exponential number, and parsing this json results in this value being returned as a string. This PR ensures difficulty is in fact a number by calling `parseFloat(BigNumber(difficulty).toFixed())` before returning a block by hash. 

```
{
  "hash": "1915264161530d46071964f7adcd97dc3f645ef6b3e00a850571c9e75fb4ad46",
  "confirmations": 1,
  "strippedsize": 228,
  "size": 264,
  "weight": 948,
  "height": 1649,
  "version": 536870912,
  "versionHex": "20000000",
  "merkleroot": "e0b2c829e72198339793e169eea05808842d9cc396b9c14045b1736d0381da3e",
  "tx": [
    "e0b2c829e72198339793e169eea05808842d9cc396b9c14045b1736d0381da3e"
  ],
  "time": 1580279280,
  "mediantime": 1580279279,
  "nonce": 0,
  "bits": "207fffff",
  "difficulty": 4.656542373906925e-10,
  "chainwork": "0000000000000000000000000000000000000000000000000000000000000ce4",
  "previousblockhash": "0a6d1a4badd577b58c6e74b18482df58af4cab0b44f3f860de9fbcdcba26f305"
}
```

### Submission Checklist :pencil:

- [x] Add proper converting of exponential number to number in `BitcoinRpcProvider`
- [x] Add tests 
