### PR TITLE
Update generateblock for bitcoin 0.18.0

### DIFF
--- a/packages/bitcoin-rpc-provider/lib/BitcoinRpcProvider.js
+++ b/packages/bitcoin-rpc-provider/lib/BitcoinRpcProvider.js
@@ -80,7 +80,8 @@ export default class BitcoinRpcProvider extends JsonRpcProvider {
   }
 
   async generateBlock (numberOfBlocks) {
-    return this.jsonrpc('generate', numberOfBlocks)
+    const newAddress = await this.jsonrpc('getnewaddress')
+    return this.jsonrpc('generatetoaddress', numberOfBlocks, newAddress)
   }
 
   async getBlockByHash (blockHash, includeTx = false) {

--- a/test/integration/chain/chain.js
+++ b/test/integration/chain/chain.js
@@ -20,10 +20,28 @@ function testGetBlock (chain) {
   })
 }
 
-describe('Send Transactions', function () {
+function testGenerateBlock (chain) {
+  it('should generate a new block', async () => {
+    const blockHeightBefore = await chain.client.chain.getBlockHeight()
+    await chain.client.chain.generateBlock(1)
+    const blockHeightAfter = await chain.client.chain.getBlockHeight()
+
+    expect(blockHeightAfter).to.equal(blockHeightBefore + 1)
+  })
+}
+
+describe('Block Numbers', function () {
   this.timeout(config.timeout)
 
-  describe('Bitcoin - Ledger', () => {
+  describe('Bitcoin - Node', () => {
     testGetBlock(chains.bitcoinWithNode)
+  })
+})
+
+describe('Block Generate', function () {
+  this.timeout(config.timeout)
+
+  describe('Bitcoin - Node', () => {
+    testGenerateBlock(chains.bitcoinWithNode)
   })
 })

--- a/test/integration/config.js
+++ b/test/integration/config.js
@@ -1,7 +1,7 @@
 export default {
   bitcoin: {
     rpc: {
-      host: 'http://localhost:18332',
+      host: 'http://localhost:18443',
       username: 'bitcoin',
       password: 'local321'
     },


### PR DESCRIPTION
### Description

`generate` is deprecated in Bitcoin `0.18.0`. It is recommended to use `generatetoaddress` instead. 

This PR modified `generateBlock` in `BitcoinRpcProvider` to first `getnewaddress` then `generatetoaddress` in order to generate a block. 

It also modified the config port to use `18443` instead of `18332`  (new regtest port in `0.18.0`)

### Submission Checklist :pencil:

- [x] Modify `generateBlock` to use `generatetoaddress` instead of deprecated call `generate`
- [x] Test with `test/integration/chain.js`
- [x] Modify config to use `18443` Bitcoin port instead of `18332` (new regtest port in `0.18.0`)