### PR TITLE
Abstract BitcoinEsploraApiProvider

### DIFF
--- a/packages/bitcoin-esplora-api-provider/lib/BitcoinEsploraApiProvider.js
+++ b/packages/bitcoin-esplora-api-provider/lib/BitcoinEsploraApiProvider.js
@@ -55,11 +55,13 @@ export default class BitcoinEsploraApiProvider extends Provider {
 
   async _getUnspentTransactions (address) {
     const response = await this._axios.get(`/address/${addressToString(address)}/utxo`)
+    const currentHeight = await this.getBlockHeight()
     return response.data.map(utxo => ({
       ...utxo,
       address: addressToString(address),
       satoshis: utxo.value,
-      amount: BigNumber(utxo.value).dividedBy(1e8).toNumber()
+      amount: BigNumber(utxo.value).dividedBy(1e8).toNumber(),
+      confirmations: utxo.status.confirmed ? (currentHeight - utxo.status.block_height) + 1 : 0
     }))
   }
 


### PR DESCRIPTION
### Description

This PR abstract elements of `BitcoinEsploraApiProvider`, so that it can be better used alongside `BitcoinRpcProvider`

One example of this is `getUnspentTransactions`

Here is a typical response from `BitcoinRpcProvider`

```
[ { txid: '36ae54d1aec4027f6d37b1f78ea4d1eed56d3a6894b29e9ecd52ba5337e58986',
    vout: 0,
    address: 'bcrt1qn6qvwfuypdglmsz0zvssperewad7j9e3f3mn86zvysl9e3ddjrts3mgctu',
    label: '',
    scriptPubKey: '00209e80c727840b51fdc04f132100e479775be917314c7733e84c243e5cc5ad90d7',
    amount: 0.00196033,
    confirmations: 3,
    spendable: false,
    solvable: false,
    safe: true,
    satoshis: 196033 } ]
```

New `EsploraApiProvider` response

```
{ txid: '8ac344f5d0b464b19cbbe91b2fb588b52e949d06e41fed3eef46d393c22f9e3b',
    vout: 0,
    status:
     { confirmed: true,
       block_height: 1577116,
       block_hash: '000000000000004c211ce88c7006bc676d8cb515abf075f8cbd64237a327d318',
       block_time: 1567802898 },
    value: 5152772,
    address: 'mtkU1Fdn1FKYSHDXbm4NJji13UbVUmhz8d',
    satoshis: 5152772,
    amount: 0.05152772,
    confirmations: 1101 } ]
```

Example 

### Submission Checklist :pencil:

- [x] Add `confirmations` to `BitcoinEsploraApiProvider` for `getUnspentTransactions`
