### PR TITLE
Add feePerByte to sendTransaction

### DIFF
--- a/packages/client/lib/Chain.js
+++ b/packages/client/lib/Chain.js
@@ -197,8 +197,8 @@ export default class Chain {
    * @param {!string} from - The address from which the message is signed.
    * @return {Promise<string>} Resolves with a signed transaction object.
    */
-  async buildTransaction (to, value, data, from) {
-    return this.client.getMethod('buildTransaction')(to, value, data, from)
+  async buildTransaction (to, value, data, from, feePerByte) {
+    return this.client.getMethod('buildTransaction')(to, value, data, from, feePerByte)
   }
 
   /**
@@ -206,8 +206,8 @@ export default class Chain {
    * @param {string[]} transactions - to, value, data, from.
    * @return {Promise<string>} Resolves with a signed transaction object.
    */
-  async buildBatchTransaction (transactions) {
-    return this.client.getMethod('buildBatchTransaction')(transactions)
+  async buildBatchTransaction (transactions, feePerByte) {
+    return this.client.getMethod('buildBatchTransaction')(transactions, feePerByte)
   }
 
   /**
@@ -218,8 +218,8 @@ export default class Chain {
    * @param {!string} from - The address from which the message is signed.
    * @return {Promise<string>} Resolves with a signed transaction.
    */
-  async sendTransaction (to, value, data, from) {
-    return this.client.getMethod('sendTransaction')(to, value, data, from)
+  async sendTransaction (to, value, data, from, feePerByte) {
+    return this.client.getMethod('sendTransaction')(to, value, data, from, feePerByte)
   }
 
   /**
@@ -227,8 +227,8 @@ export default class Chain {
    * @param {string[]} transactions - to, value, data, from.
    * @return {Promise<string>} Resolves with a signed transaction.
    */
-  async sendBatchTransaction (transactions) {
-    return this.client.getMethod('sendBatchTransaction')(transactions)
+  async sendBatchTransaction (transactions, feePerByte) {
+    return this.client.getMethod('sendBatchTransaction')(transactions, feePerByte)
   }
 
   /**

--- a/test/integration/common.js
+++ b/test/integration/common.js
@@ -27,7 +27,7 @@ bitcoinWithNode.addProvider(new providers.bitcoin.BitcoinSwapProvider({ network:
 
 const bitcoinWithJs = new Client()
 bitcoinWithJs.addProvider(new providers.bitcoin.BitcoinRpcProvider(config.bitcoin.rpc.host, config.bitcoin.rpc.username, config.bitcoin.rpc.password))
-bitcoinWithJs.addProvider(new providers.bitcoin.BitcoinJsWalletProvider(bitcoinNetworks[config.bitcoin.network], config.bitcoin.rpc.host, config.bitcoin.rpc.username, config.bitcoin.rpc.password, generateMnemonic(256), 'bech32'))
+bitcoinWithJs.addProvider(new providers.bitcoin.BitcoinJsWalletProvider(bitcoinNetworks[config.bitcoin.network], generateMnemonic(256), 'bech32'))
 bitcoinWithJs.addProvider(new providers.bitcoin.BitcoinSwapProvider({ network: bitcoinNetworks[config.bitcoin.network] }, 'p2wsh'))
 
 // TODO: required for BITCOIN too?


### PR DESCRIPTION
### Description

This PR adds `feePerByte` option to `sendTransaction`. 

### Submission Checklist :pencil:

- [x] Add `feePerByte` argument to `sendTranasction`, `sendBatchTransaction` for both `BitcoinJsWalletProvider` and `BitcoinLedgerProvider`
