### PR TITLE
Add initial tests for apis like EsploraApiProvider

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "lint": "standard $npm_package_options_standard",
     "bootstrap": "lerna bootstrap --force-local",
     "test": "cross-env NODE_ENV=test nyc mocha packages/*/test/unit $npm_package_options_mocha",
+    "test:api": "cross-env NODE_ENV=test nyc mocha test/integration/api $npm_package_options_mocha",
     "test:chain": "cross-env NODE_ENV=test nyc mocha test/integration/chain $npm_package_options_mocha",
     "test:swap": "cross-env NODE_ENV=test nyc mocha test/integration/swap $npm_package_options_mocha",
     "test:tx": "cross-env NODE_ENV=test nyc mocha test/integration/tx $npm_package_options_mocha",

--- a/test/integration/api/api.js
+++ b/test/integration/api/api.js
@@ -1,0 +1,26 @@
+/* eslint-env mocha */
+import chai, { expect } from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import { chains } from '../common'
+import config from '../config'
+
+process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = 0
+
+chai.use(chaiAsPromised)
+chai.use(require('chai-bignumber')())
+
+function testGetFeePerByte (chain) {
+  it('Should get the correct feePerByte', async () => {
+    const feePerByte = await chain.client.getMethod('getFeePerByte')(1)
+
+    expect(feePerByte).to.equal(1)
+  })
+}
+
+describe('API', function () {
+  this.timeout(config.timeout)
+
+  describe('Bitcoin Esplora - Js', () => {
+    testGetFeePerByte(chains.bitcoinWithEsplora)
+  })
+})

--- a/test/integration/common.js
+++ b/test/integration/common.js
@@ -30,6 +30,10 @@ bitcoinWithJs.addProvider(new providers.bitcoin.BitcoinRpcProvider(config.bitcoi
 bitcoinWithJs.addProvider(new providers.bitcoin.BitcoinJsWalletProvider(bitcoinNetworks[config.bitcoin.network], generateMnemonic(256), 'bech32'))
 bitcoinWithJs.addProvider(new providers.bitcoin.BitcoinSwapProvider({ network: bitcoinNetworks[config.bitcoin.network] }, 'p2wsh'))
 
+const bitcoinWithEsplora = new Client()
+bitcoinWithEsplora.addProvider(new providers.bitcoin.BitcoinEsploraApiProvider('https://blockstream.info/testnet/api'))
+bitcoinWithEsplora.addProvider(new providers.bitcoin.BitcoinJsWalletProvider(bitcoinNetworks.bitcoin_testnet, generateMnemonic(256), 'bech32'))
+
 // TODO: required for BITCOIN too?
 class RandomEthereumAddressProvider extends Provider {
   getUnusedAddress () { // Mock unique address
@@ -90,6 +94,7 @@ const chains = {
   bitcoinWithLedger: { id: 'Bitcoin Ledger', name: 'bitcoin', client: bitcoinWithLedger, network: bitcoinNetwork },
   bitcoinWithNode: { id: 'Bitcoin Node', name: 'bitcoin', client: bitcoinWithNode, network: bitcoinNetwork },
   bitcoinWithJs: { id: 'Bitcoin Js', name: 'bitcoin', client: bitcoinWithJs, network: bitcoinNetwork },
+  bitcoinWithEsplora: { id: 'Bitcoin Esplora', name: 'bitcoin', client: bitcoinWithEsplora },
   ethereumWithMetaMask: { id: 'Ethereum MetaMask', name: 'ethereum', client: ethereumWithMetaMask },
   ethereumWithNode: { id: 'Ethereum Node', name: 'ethereum', client: ethereumWithNode },
   ethereumWithLedger: { id: 'Ethereum Ledger', name: 'ethereum', client: ethereumWithLedger },


### PR DESCRIPTION
### Description

Add initial testing for API's

### Submission Checklist :pencil:

- [x] Add initial testing for API's such as `EsploraApiProvider`