### PR TITLE
Revert "Add feePerByte to sendTransaction"

### DIFF
--- a/packages/bitcoin-ledger-provider/lib/BitcoinLedgerProvider.js
+++ b/packages/bitcoin-ledger-provider/lib/BitcoinLedgerProvider.js
@@ -50,7 +50,7 @@ export default class BitcoinLedgerProvider extends LedgerProvider {
     return app.signMessageNew(address.derivationPath, hex)
   }
 
-  async _buildTransaction (_outputs, feePerByte) {
+  async _buildTransaction (_outputs) {
     const app = await this.getApp()
 
     const totalValue = _outputs.reduce((prev, curr) => {
@@ -58,7 +58,7 @@ export default class BitcoinLedgerProvider extends LedgerProvider {
     }, BigNumber(0)).toNumber()
 
     const unusedAddress = await this.getUnusedAddress(true)
-    const { inputs, change } = await this.getInputsForAmount(totalValue, feePerByte)
+    const { inputs, change } = await this.getInputsForAmount(totalValue)
     const ledgerInputs = await this.getLedgerInputs(inputs)
     const paths = inputs.map(utxo => utxo.derivationPath)
 
@@ -89,25 +89,25 @@ export default class BitcoinLedgerProvider extends LedgerProvider {
     )
   }
 
-  async buildTransaction (to, value, data, from, feePerByte) {
-    return this._buildTransaction([{ to, value }], feePerByte)
+  async buildTransaction (to, value, data, from) {
+    return this._buildTransaction([{ to, value }])
   }
 
-  async buildBatchTransaction (transactions, feePerByte) {
-    return this._buildTransaction(transactions, feePerByte)
+  async buildBatchTransaction (transactions) {
+    return this._buildTransaction(transactions)
   }
 
-  async _sendTransaction (transactions, feePerByte) {
-    const signedTransaction = await this._buildTransaction(transactions, feePerByte)
+  async _sendTransaction (transactions) {
+    const signedTransaction = await this._buildTransaction(transactions)
     return this.getMethod('sendRawTransaction')(signedTransaction)
   }
 
-  async sendTransaction (to, value, data, from, feePerByte) {
-    return this._sendTransaction([{ to, value }], feePerByte)
+  async sendTransaction (to, value, data, from) {
+    return this._sendTransaction([{ to, value }])
   }
 
-  async sendBatchTransaction (transactions, feePerByte) {
-    return this._sendTransaction(transactions, feePerByte)
+  async sendBatchTransaction (transactions) {
+    return this._sendTransaction(transactions)
   }
 
   async signP2SHTransaction (inputTxHex, tx, address, vout, outputScript, lockTime = 0, segwit = false, index = 0) {
@@ -188,7 +188,7 @@ export default class BitcoinLedgerProvider extends LedgerProvider {
     return valueBuffer.reverse()
   }
 
-  async getInputsForAmount (amount, feePerByte, numAddressPerCall = 100) {
+  async getInputsForAmount (amount, numAddressPerCall = 100) {
     let addressIndex = 0
     let changeAddresses = []
     let nonChangeAddresses = []
@@ -198,7 +198,7 @@ export default class BitcoinLedgerProvider extends LedgerProvider {
     }
 
     const feePerBytePromise = this.getMethod('getFeePerByte')()
-    if (feePerByte === undefined) feePerByte = false
+    let feePerByte = false
 
     while (addressCountMap.change < ADDRESS_GAP || addressCountMap.nonChange < ADDRESS_GAP) {
       let addrList = []

--- a/packages/client/lib/Chain.js
+++ b/packages/client/lib/Chain.js
@@ -197,8 +197,8 @@ export default class Chain {
    * @param {!string} from - The address from which the message is signed.
    * @return {Promise<string>} Resolves with a signed transaction object.
    */
-  async buildTransaction (to, value, data, from, feePerByte) {
-    return this.client.getMethod('buildTransaction')(to, value, data, from, feePerByte)
+  async buildTransaction (to, value, data, from) {
+    return this.client.getMethod('buildTransaction')(to, value, data, from)
   }
 
   /**
@@ -206,8 +206,8 @@ export default class Chain {
    * @param {string[]} transactions - to, value, data, from.
    * @return {Promise<string>} Resolves with a signed transaction object.
    */
-  async buildBatchTransaction (transactions, feePerByte) {
-    return this.client.getMethod('buildBatchTransaction')(transactions, feePerByte)
+  async buildBatchTransaction (transactions) {
+    return this.client.getMethod('buildBatchTransaction')(transactions)
   }
 
   /**
@@ -218,8 +218,8 @@ export default class Chain {
    * @param {!string} from - The address from which the message is signed.
    * @return {Promise<string>} Resolves with a signed transaction.
    */
-  async sendTransaction (to, value, data, from, feePerByte) {
-    return this.client.getMethod('sendTransaction')(to, value, data, from, feePerByte)
+  async sendTransaction (to, value, data, from) {
+    return this.client.getMethod('sendTransaction')(to, value, data, from)
   }
 
   /**
@@ -227,8 +227,8 @@ export default class Chain {
    * @param {string[]} transactions - to, value, data, from.
    * @return {Promise<string>} Resolves with a signed transaction.
    */
-  async sendBatchTransaction (transactions, feePerByte) {
-    return this.client.getMethod('sendBatchTransaction')(transactions, feePerByte)
+  async sendBatchTransaction (transactions) {
+    return this.client.getMethod('sendBatchTransaction')(transactions)
   }
 
   /**

--- a/test/integration/common.js
+++ b/test/integration/common.js
@@ -27,7 +27,7 @@ bitcoinWithNode.addProvider(new providers.bitcoin.BitcoinSwapProvider({ network:
 
 const bitcoinWithJs = new Client()
 bitcoinWithJs.addProvider(new providers.bitcoin.BitcoinRpcProvider(config.bitcoin.rpc.host, config.bitcoin.rpc.username, config.bitcoin.rpc.password))
-bitcoinWithJs.addProvider(new providers.bitcoin.BitcoinJsWalletProvider(bitcoinNetworks[config.bitcoin.network], generateMnemonic(256), 'bech32'))
+bitcoinWithJs.addProvider(new providers.bitcoin.BitcoinJsWalletProvider(bitcoinNetworks[config.bitcoin.network], config.bitcoin.rpc.host, config.bitcoin.rpc.username, config.bitcoin.rpc.password, generateMnemonic(256), 'bech32'))
 bitcoinWithJs.addProvider(new providers.bitcoin.BitcoinSwapProvider({ network: bitcoinNetworks[config.bitcoin.network] }, 'p2wsh'))
 
 const bitcoinWithEsplora = new Client()

--- a/test/integration/tx/transactions.js
+++ b/test/integration/tx/transactions.js
@@ -47,49 +47,6 @@ function testBatchTransaction (chain) {
   })
 }
 
-function testTransactionFees (chain) {
-  it('should allow for manual feePerByte input', async () => {
-    const addr = (await chain.client.wallet.getUnusedAddress()).address
-    const value = config[chain.name].value
-
-    const feePerByte = await chain.client.getMethod('getFeePerByte')(1)
-
-    const tx = await chain.client.chain.sendTransaction(addr, value, null, null, feePerByte)
-    await chains.bitcoinWithNode.client.chain.generateBlock(1)
-    const fees = await getTxFees(chain, tx)
-
-    const addr2 = (await chain.client.wallet.getUnusedAddress()).address
-    const tx2 = await chain.client.chain.sendTransaction(addr2, value, null, null, feePerByte * 2)
-    await chains.bitcoinWithNode.client.chain.generateBlock(1)
-    const doubleFees = await getTxFees(chain, tx2)
-
-    expect(fees * 2).to.equal(doubleFees)
-  })
-
-  it('should allow for manual feePerByte input for batch Transactions', async () => {
-    const addr1 = (await chain.client.wallet.getUnusedAddress()).address
-    await fundUnusedBitcoinAddress(chain)
-    const addr2 = (await chain.client.wallet.getUnusedAddress()).address
-    const value = config[chain.name].value
-
-    const feePerByte = await chain.client.getMethod('getFeePerByte')(1)
-
-    const tx = await chain.client.chain.sendBatchTransaction([{ to: addr1, value }, { to: addr2, value }], feePerByte)
-    await chains.bitcoinWithNode.client.chain.generateBlock(1)
-    const fees = await getTxFees(chain, tx)
-
-    const addr3 = (await chain.client.wallet.getUnusedAddress()).address
-    await fundUnusedBitcoinAddress(chain)
-    const addr4 = (await chain.client.wallet.getUnusedAddress()).address
-
-    const tx2 = await chain.client.chain.sendBatchTransaction([{ to: addr3, value }, { to: addr4, value }], feePerByte * 2)
-    await chains.bitcoinWithNode.client.chain.generateBlock(1)
-    const doubleFees = await getTxFees(chain, tx2)
-
-    expect(fees * 2).to.equal(doubleFees)
-  })
-}
-
 function testSignBatchP2SHTransaction (chain) {
   it('Should redeem two P2SH\'s', async () => {
     const network = chain.network
@@ -217,25 +174,6 @@ function testSignBatchP2SHTransaction (chain) {
   })
 }
 
-async function getTxFees (chain, transactionHash) {
-  const rawTx = await chain.client.getMethod('getTransactionHex')(transactionHash)
-  const txObject = await chain.client.getMethod('decodeRawTransaction')(rawTx)
-  const vins = txObject._raw.data.vin
-  const vouts = txObject._raw.data.vout
-
-  let vinsValue = 0
-  for (let i = 0; i < vins.length; i++) {
-    const rawVinTx = await chain.client.getMethod('getTransactionHex')(vins[i].txid)
-    const vinTxObject = await chain.client.getMethod('decodeRawTransaction')(rawVinTx)
-    const vinVouts = vinTxObject._raw.data.vout
-    vinsValue += vinVouts[vins[i].vout].value * (10 ** 8)
-  }
-
-  const voutsValue = vouts.reduce((acc, vout) => acc + parseInt((vout.value * (10 ** 8))), 0)
-
-  return vinsValue - voutsValue
-}
-
 describe('Send Transactions', function () {
   this.timeout(config.timeout)
 
@@ -269,22 +207,6 @@ describe('Send Batch Transactions', function () {
     before(async function () { await importBitcoinAddresses(chains.bitcoinWithJs) })
     beforeEach(async function () { await fundUnusedBitcoinAddress(chains.bitcoinWithJs) })
     testBatchTransaction(chains.bitcoinWithJs)
-  })
-})
-
-describe('Send Transactions with custom fees', function () {
-  this.timeout(config.timeout)
-
-  describe('Bitcoin - Ledger', () => {
-    before(async function () { await importBitcoinAddresses(chains.bitcoinWithLedger) })
-    beforeEach(async function () { await fundUnusedBitcoinAddress(chains.bitcoinWithLedger) })
-    testTransactionFees(chains.bitcoinWithLedger)
-  })
-
-  describe('Bitcoin - Js', () => {
-    before(async function () { await importBitcoinAddresses(chains.bitcoinWithJs) })
-    beforeEach(async function () { await fundUnusedBitcoinAddress(chains.bitcoinWithJs) })
-    testTransactionFees(chains.bitcoinWithJs)
   })
 })
 


### PR DESCRIPTION
This PR revert liquality/chainabstractionlayer#213 as per a discussion with @monokh. It seems to make more sense to have some type of fee object, with details such as `low`, `med`, `high` fees or number of confirmation per block, to make sure it's abstracted across both chains. This will require further discussion to determine what the best way to implement this is. 