### PR TITLE
SwapProviders: Remove polling from find functions

### DIFF
--- a/packages/bitcoin-swap-provider/lib/BitcoinSwapProvider.js
+++ b/packages/bitcoin-swap-provider/lib/BitcoinSwapProvider.js
@@ -247,9 +247,12 @@ export default class BitcoinSwapProvider extends Provider {
       tx => this.doesTransactionMatchRedeem(initiationTxHash, tx, recipientAddress, false)
     )
 
-    return {
-      ...claimSwapTransaction,
-      secret: await this.getSwapSecret(claimSwapTransaction.hash)
+    if (claimSwapTransaction) {
+      const secret = await this.getSwapSecret(claimSwapTransaction.hash)
+      return {
+        ...claimSwapTransaction,
+        secret
+      }
     }
   }
 

--- a/packages/client/lib/Swap.js
+++ b/packages/client/lib/Swap.js
@@ -15,11 +15,11 @@ export default class Swap {
    * @param {!string} refundAddress - Refund address
    * @param {!string} secretHash - Secret hash
    * @param {!string} expiration - Expiration time
-   * @param {number} [startBlock] - The block number to start finding from (Optional)
+   * @param {!number} blockNumber - The block number to find the transaction in
    * @return {Promise<string>} Resolves with a transaction identifier.
    */
-  async findInitiateSwapTransaction (value, recipientAddress, refundAddress, secretHash, expiration, startBlock = null) {
-    return this.client.getMethod('findInitiateSwapTransaction')(value, recipientAddress, refundAddress, secretHash, expiration, startBlock)
+  async findInitiateSwapTransaction (value, recipientAddress, refundAddress, secretHash, expiration, blockNumber) {
+    return this.client.getMethod('findInitiateSwapTransaction')(value, recipientAddress, refundAddress, secretHash, expiration, blockNumber)
   }
 
   /**
@@ -29,11 +29,11 @@ export default class Swap {
    * @param {!string} refundAddress - Refund address
    * @param {!string} secretHash - Secret hash
    * @param {!string} expiration - Expiration time
-   * @param {number} [startBlock] - The block number to start finding from (Optional)
+   * @param {!number} blockNumber - The block number to find the transaction in
    * @return {Promise<string>} Resolves with a transaction identifier.
    */
-  async findClaimSwapTransaction (initiationTxHash, recipientAddress, refundAddress, secretHash, expiration, startBlock = null) {
-    return this.client.getMethod('findClaimSwapTransaction')(initiationTxHash, recipientAddress, refundAddress, secretHash, expiration, startBlock)
+  async findClaimSwapTransaction (initiationTxHash, recipientAddress, refundAddress, secretHash, expiration, blockNumber) {
+    return this.client.getMethod('findClaimSwapTransaction')(initiationTxHash, recipientAddress, refundAddress, secretHash, expiration, blockNumber)
   }
 
   /**
@@ -43,16 +43,16 @@ export default class Swap {
    * @param {!string} refundAddress - Refund address for the swap in hex.
    * @param {!string} secretHash - Secret hash for the swap in hex.
    * @param {!number} expiration - Expiration time for the swap.
-   * @param {number} [startBlock] - The block number to start finding from (Optional)
+   * @param {!number} blockNumber - The block number to find the transaction in
    * @return {Promise<string, TypeError>} Resolves with refund swap transaction hash.
    *  Rejects with InvalidProviderResponseError if provider's response is invalid.
    */
-  async findRefundSwapTransaction (initiationTxHash, recipientAddress, refundAddress, secretHash, expiration, startBlock = null) {
+  async findRefundSwapTransaction (initiationTxHash, recipientAddress, refundAddress, secretHash, expiration, blockNumber) {
     if (!(/^[A-Fa-f0-9]+$/.test(initiationTxHash))) {
       throw new TypeError('Initiation transaction hash should be a valid hex string')
     }
 
-    return this.client.getMethod('findRefundSwapTransaction')(initiationTxHash, recipientAddress, refundAddress, secretHash, expiration, startBlock)
+    return this.client.getMethod('findRefundSwapTransaction')(initiationTxHash, recipientAddress, refundAddress, secretHash, expiration, blockNumber)
   }
 
   /**

--- a/test/integration/swap/singleChain.js
+++ b/test/integration/swap/singleChain.js
@@ -173,17 +173,14 @@ describe('Swap Single Chain Flow', function () {
   this.timeout(config.timeout)
 
   describe('Bitcoin - Ledger', () => {
-    mineBitcoinBlocks()
     testSingle(chains.bitcoinWithLedger)
   })
 
   describe('Bitcoin - Node', () => {
-    mineBitcoinBlocks()
     testSingle(chains.bitcoinWithNode)
   })
 
   describe('Bitcoin - Js', () => {
-    mineBitcoinBlocks()
     before(async function () {
       await importBitcoinAddresses(chains.bitcoinWithJs)
     })


### PR DESCRIPTION
### Description

Removes the long polling from the swap providers. 

Swap find functions now require a blockNumber to check in

### Submission Checklist :pencil:

- [x] BitcoinSwapProvider
- [x] EthereumSwapProvider
- [x] EthereumERC20SwapProvider
