### PR TITLE
Fix fee non integer issue causing not enough balance error

### DIFF
--- a/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.js
+++ b/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.js
@@ -376,7 +376,7 @@ export default class BitcoinJsWalletProvider extends Provider {
 
       const targets = _targets.map((target, i) => ({ id: 'main', value: target.value }))
 
-      const { inputs, outputs, fee } = coinselect(utxos, targets, feePerByte)
+      const { inputs, outputs, fee } = coinselect(utxos, targets, Math.ceil(feePerByte))
 
       if (inputs && outputs) {
         let change = outputs.find(output => output.id !== 'main')

--- a/packages/bitcoin-ledger-provider/lib/BitcoinLedgerProvider.js
+++ b/packages/bitcoin-ledger-provider/lib/BitcoinLedgerProvider.js
@@ -232,7 +232,7 @@ export default class BitcoinLedgerProvider extends LedgerProvider {
 
       const targets = _targets.map((target, i) => ({ id: 'main', value: target.value }))
 
-      const { inputs, outputs, fee } = coinselect(utxos, targets, feePerByte)
+      const { inputs, outputs, fee } = coinselect(utxos, targets, Math.ceil(feePerByte))
 
       if (inputs && outputs) {
         let change = outputs.find(output => output.id !== 'main')


### PR DESCRIPTION
### Description

This PR fixes the issue with fees from esplora API being decimals, causing `coinselect` to fail

### Submission Checklist :pencil:

- [x] Fix fee non integer issue causing not enough balance error
