### PR TITLE
Remove unnecessary uri js wallet provider

### DIFF
--- a/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.js
+++ b/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.js
@@ -1,5 +1,4 @@
 import Provider from '@liquality/provider'
-import JsonRpcProvider from '@liquality/jsonrpc-provider'
 import { AddressTypes } from '@liquality/bitcoin-utils'
 import * as bitcoin from 'bitcoinjs-lib'
 import * as bitcoinMessage from 'bitcoinjs-message'
@@ -23,7 +22,7 @@ const ADDRESS_TYPE_TO_LEDGER_PREFIX = {
 }
 
 export default class BitcoinJsWalletProvider extends Provider {
-  constructor (network, uri, username, password, mnemonic, addressType = 'bech32') {
+  constructor (network, mnemonic, addressType = 'bech32') {
     super()
     if (!AddressTypes.includes(addressType)) {
       throw new Error(`addressType must be one of ${AddressTypes.join(',')}`)
@@ -34,7 +33,6 @@ export default class BitcoinJsWalletProvider extends Provider {
     const derivationPath = `${ADDRESS_TYPE_TO_LEDGER_PREFIX[addressType]}'/${network.coinType}'/0'/`
     this._derivationPath = derivationPath
     this._network = network
-    this._rpc = new JsonRpcProvider(uri, username, password)
     this._mnemonic = mnemonic
     this._addressType = addressType
   }

--- a/test/integration/common.js
+++ b/test/integration/common.js
@@ -27,7 +27,7 @@ bitcoinWithNode.addProvider(new providers.bitcoin.BitcoinSwapProvider({ network:
 
 const bitcoinWithJs = new Client()
 bitcoinWithJs.addProvider(new providers.bitcoin.BitcoinRpcProvider(config.bitcoin.rpc.host, config.bitcoin.rpc.username, config.bitcoin.rpc.password))
-bitcoinWithJs.addProvider(new providers.bitcoin.BitcoinJsWalletProvider(bitcoinNetworks[config.bitcoin.network], config.bitcoin.rpc.host, config.bitcoin.rpc.username, config.bitcoin.rpc.password, generateMnemonic(256), 'bech32'))
+bitcoinWithJs.addProvider(new providers.bitcoin.BitcoinJsWalletProvider(bitcoinNetworks[config.bitcoin.network], generateMnemonic(256), 'bech32'))
 bitcoinWithJs.addProvider(new providers.bitcoin.BitcoinSwapProvider({ network: bitcoinNetworks[config.bitcoin.network] }, 'p2wsh'))
 
 const bitcoinWithEsplora = new Client()


### PR DESCRIPTION
### Description

This PR removes unnecessary `uri`, `username`, and `password` from `JsWalletProvider`

### Submission Checklist :pencil:

- [x] Remove unnecessary `uri`, `username`, and `password` from `JsWalletProvider`
