### PR TITLE
Add txInputIndex info for signBatchP2SHTransaction in JsWalletProvider

### DIFF
--- a/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.js
+++ b/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.js
@@ -154,11 +154,12 @@ export default class BitcoinJsWalletProvider extends Provider {
 
     let sigs = []
     for (let i = 0; i < inputs.length; i++) {
+      const index = inputs[i].txInputIndex ? inputs[i].txInputIndex : inputs[i].index
       let sigHash
       if (segwit) {
-        sigHash = tx.hashForWitnessV0(inputs[i].index, inputs[i].outputScript, inputs[i].vout.vSat, bitcoin.Transaction.SIGHASH_ALL) // AMOUNT NEEDS TO BE PREVOUT AMOUNT
+        sigHash = tx.hashForWitnessV0(index, inputs[i].outputScript, inputs[i].vout.vSat, bitcoin.Transaction.SIGHASH_ALL) // AMOUNT NEEDS TO BE PREVOUT AMOUNT
       } else {
-        sigHash = tx.hashForSignature(inputs[i].index, inputs[i].outputScript, bitcoin.Transaction.SIGHASH_ALL)
+        sigHash = tx.hashForSignature(index, inputs[i].outputScript, bitcoin.Transaction.SIGHASH_ALL)
       }
 
       const sig = bitcoin.script.signature.encode(keyPairs[i].sign(sigHash), bitcoin.Transaction.SIGHASH_ALL)


### PR DESCRIPTION
### Description

This PR adds `txInputIndex` for inputs into `signBatchP2SHTransaction` in `JsWalletProvider`. This is because currently `signBatchP2SHTransaction` for `BitcoinLedgerProvider` and `BitcoinJsWalletProvider` assume that the index for a specific tx is always identical. This works fine if you are redeeming a single P2SH, but if you try to redeem multiple P2SH's, this will fail. 

For example: https://gist.github.com/mattBlackDesign/4cd7bfc1ddb94b8e70b6e4671f780414#file-createmanysigs-js-L20

If you are redeeming from multiple p2sh's, the following line fails for `BitcoinLedgerProvider` `inputsToSign.push({ inputTxHex: col.txRaw, index: i, vout: col.colVout, outputScript: colOutputScript })`

This is because Ledger Provider expects the index to be the index relative to the index of the input in the transaction it is coming from. 

Whereas, Js Wallet Provider expects it to be the index that the particular input will be in the the transaction that is created. 

To fix this, the following code can be used: 

`inputsToSign.push({ inputTxHex: col.txRaw, index: col.colVout.index, txInputIndex: i, vout: col.colVout, outputScript: colOutputScript })`

An example of this in action can be seen here: https://github.com/AtomicLoans/chainabstractionlayer-loans/blob/98ea4742b2fa3e263ebfa395ff7753bf3f33981e/packages/bitcoin-collateral-provider/lib/BitcoinCollateralProvider.js#L568

### Submission Checklist :pencil:

- [x] Add `txInputIndex` for `signBatchP2SHTransaction` in `BitcoinJsWalletProvider`
