### PR TITLE
Bitcoin providers: fix used address calculation

### DIFF
--- a/packages/bitcoin-esplora-api-provider/lib/BitcoinEsploraApiProvider.js
+++ b/packages/bitcoin-esplora-api-provider/lib/BitcoinEsploraApiProvider.js
@@ -75,6 +75,20 @@ export default class BitcoinEsploraApiProvider extends Provider {
     return utxos
   }
 
+  async _getAddressTransactionCount (address) {
+    const response = await this._axios.get(`/address/${addressToString(address)}`)
+    return response.data.chain_stats.tx_count + response.data.mempool_stats.tx_count
+  }
+
+  async getAddressTransactionCounts (addresses) {
+    const transactionCountsArray = await Promise.all(addresses.map(async (addr) => {
+      const txCount = await this._getAddressTransactionCount(addr)
+      return { [addr]: txCount }
+    }))
+    const transactionCounts = Object.assign({}, ...transactionCountsArray)
+    return transactionCounts
+  }
+
   async getTransactionHex (transactionHash) {
     const response = await this._axios.get(`/tx/${transactionHash}/hex`)
     return response.data

--- a/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.js
+++ b/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.js
@@ -277,10 +277,10 @@ export default class BitcoinJsWalletProvider extends Provider {
         addrList = addrList.concat(nonChangeAddresses)
       }
 
-      let totalUsedAddresses = await this.getMethod('getUnspentTransactions')(addrList)
+      const transactionCounts = await this.getMethod('getAddressTransactionCounts')(addrList)
 
       for (let address of addrList) {
-        const isUsed = totalUsedAddresses.find(a => address.equals(a))
+        const isUsed = transactionCounts[address] > 0
         const isChangeAddress = changeAddresses.find(a => address.equals(a))
         const key = isChangeAddress ? 'change' : 'nonChange'
 

--- a/packages/bitcoin-ledger-provider/lib/BitcoinLedgerProvider.js
+++ b/packages/bitcoin-ledger-provider/lib/BitcoinLedgerProvider.js
@@ -379,10 +379,10 @@ export default class BitcoinLedgerProvider extends LedgerProvider {
         addrList = addrList.concat(nonChangeAddresses)
       }
 
-      let totalUsedAddresses = await this.getMethod('getUnspentTransactions')(addrList)
+      const transactionCounts = await this.getMethod('getAddressTransactionCounts')(addrList)
 
       for (let address of addrList) {
-        const isUsed = totalUsedAddresses.find(a => address.equals(a))
+        const isUsed = transactionCounts[address] > 0
         const isChangeAddress = changeAddresses.find(a => address.equals(a))
         const key = isChangeAddress ? 'change' : 'nonChange'
 

--- a/packages/bitcoin-rpc-provider/lib/BitcoinRpcProvider.js
+++ b/packages/bitcoin-rpc-provider/lib/BitcoinRpcProvider.js
@@ -70,6 +70,17 @@ export default class BitcoinRpcProvider extends JsonRpcProvider {
     return utxos.map(utxo => ({ ...utxo, satoshis: BigNumber(utxo.amount).times(1e8).toNumber() }))
   }
 
+  async getAddressTransactionCounts (addresses) {
+    const receivedAddresses = await this.jsonrpc('listreceivedbyaddress', 0, false, true)
+    const transactionCountsArray = addresses.map(addr => {
+      const receivedAddress = receivedAddresses.find(receivedAddress => receivedAddress.address === addr)
+      const transactionCount = receivedAddress ? receivedAddress.txids.length : 0
+      return { [addr]: transactionCount }
+    })
+    const transactionCounts = Object.assign({}, ...transactionCountsArray)
+    return transactionCounts
+  }
+
   async getReceivedByAddress (address) {
     address = addressToString(address)
     return this.jsonrpc('getreceivedbyaddress', address)

--- a/packages/litecoin-js-wallet-provider/lib/LitecoinJsWalletProvider.js
+++ b/packages/litecoin-js-wallet-provider/lib/LitecoinJsWalletProvider.js
@@ -278,10 +278,10 @@ export default class BitcoinJsWalletProvider extends Provider {
         addrList = addrList.concat(nonChangeAddresses)
       }
 
-      let totalUsedAddresses = await this.getMethod('getUnspentTransactions')(addrList)
+      const transactionCounts = await this.getMethod('getAddressTransactionCounts')(addrList)
 
       for (let address of addrList) {
-        const isUsed = totalUsedAddresses.find(a => address.equals(a))
+        const isUsed = transactionCounts[address] > 0
         const isChangeAddress = changeAddresses.find(a => address.equals(a))
         const key = isChangeAddress ? 'change' : 'nonChange'
 


### PR DESCRIPTION
Essentially the issue is that the used addresses list was not generated correctly - it used “getUnspentTransactions” which would return empty for an address where all utxos were spent - this is wrong of course and an address is used as long as it has any transactions.
So the fix is to switch to getting tx counts from esplora and RPC