### PR TITLE
Ensure Kiba sign p2sh fns return buffers

### DIFF
--- a/packages/bitcoin-kiba-provider/lib/BitcoinKibaProvider.js
+++ b/packages/bitcoin-kiba-provider/lib/BitcoinKibaProvider.js
@@ -214,8 +214,9 @@ export default class BitcoinKibaProvider extends KibaProvider {
     }
 
     const { signature } = await this.kiba(method, params)
+    const sig = Buffer.from(signature, 'hex')
 
-    return signature
+    return sig
   }
 
   // inputs consists of [{ inputTxHex, index, vout, outputScript }]
@@ -249,7 +250,12 @@ export default class BitcoinKibaProvider extends KibaProvider {
 
     const { signatures } = await this.kiba(method, params)
 
-    return signatures
+    let sigs = []
+    for (const signature of signatures) {
+      sigs.push(Buffer.from(signature, 'hex'))
+    }
+
+    return sigs
   }
 
   async getWalletAddress (address) {


### PR DESCRIPTION
### Description

This PR ensures that Kiba Provider returns Buffer not a hex for `signP2SHTransaction` and `signBatchP2SHTransaction`

### Submission Checklist :pencil:

- [x] Ensure `signP2SHTransaction` and `signBatchP2SHTransaction` returns Buffer
