### PR TITLE
Add build and send sweep transaction for bitcoin js wallet

### DIFF
--- a/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.js
+++ b/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.js
@@ -96,7 +96,7 @@ export default class BitcoinJsWalletProvider extends BitcoinWalletProvider(Walle
     let _feePerByte = feePerByte || false
     if (_feePerByte === false) _feePerByte = await this.getMethod('getFeePerByte')()
 
-    const { inputs, outputs, change } = await this.getInputsForSweep(_outputs, _feePerByte, fixedInputs)
+    const { inputs, outputs, change } = await this.getInputsForAmount(_outputs, _feePerByte, fixedInputs, 100, true)
 
     if (change) {
       throw Error('There should not be any change for sweeping transaction')

--- a/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.js
+++ b/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.js
@@ -92,7 +92,7 @@ export default class BitcoinJsWalletProvider extends BitcoinWalletProvider(Walle
     return { hex: txb.build().toHex(), fee }
   }
 
-  async _buildSweepTransaction (externalChangeAddress, _outputs = [], feePerByte, fixedInputs) {
+  async _buildSweepTransaction (externalChangeAddress, feePerByte, _outputs = [], fixedInputs) {
     let _feePerByte = feePerByte || false
     if (_feePerByte === false) _feePerByte = await this.getMethod('getFeePerByte')()
 

--- a/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.js
+++ b/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.js
@@ -92,25 +92,20 @@ export default class BitcoinJsWalletProvider extends BitcoinWalletProvider(Walle
     return { hex: txb.build().toHex(), fee }
   }
 
-  async _buildSweepTransaction (externalChangeAddress, feePerByte, _outputs = [], fixedInputs) {
+  async _buildSweepTransaction (externalChangeAddress, feePerByte) {
     let _feePerByte = feePerByte || false
     if (_feePerByte === false) _feePerByte = await this.getMethod('getFeePerByte')()
 
-    const { inputs, outputs, change } = await this.getInputsForAmount(_outputs, _feePerByte, fixedInputs, 100, true)
+    const { inputs, outputs, change } = await this.getInputsForAmount([], _feePerByte, [], 100, true)
 
     if (change) {
       throw Error('There should not be any change for sweeping transaction')
     }
 
-    _outputs.forEach((output, i) => {
-      const spliceIndex = outputs.findIndex((sweepOutput) => output.value === sweepOutput.value)
-      outputs.splice(spliceIndex, spliceIndex + 1)
-    })
-
-    _outputs.push({
+    const _outputs = [{
       to: externalChangeAddress,
       value: outputs[0].value
-    })
+    }]
 
     return this._buildTransaction(_outputs, feePerByte, inputs)
   }

--- a/packages/bitcoin-wallet-provider/lib/BitcoinWalletProvider.js
+++ b/packages/bitcoin-wallet-provider/lib/BitcoinWalletProvider.js
@@ -292,7 +292,7 @@ export default superclass => class BitcoinWalletProvider extends superclass {
 
       const outputBalance = _targets.reduce((a, b) => a + (b['value'] || 0), 0)
 
-      const amountToSend = utxoBalance - (feePerByte * (((_targets.length + 1) * 40) + (utxos.length * 155))) // todo better calculation
+      const amountToSend = utxoBalance - (feePerByte * (((_targets.length + 1) * 39) + (utxos.length * 153))) // todo better calculation
 
       let targets = _targets.map((target, i) => ({ id: 'main', value: target.value }))
       targets.push({ id: 'main', value: amountToSend - outputBalance })
@@ -329,7 +329,7 @@ export default superclass => class BitcoinWalletProvider extends superclass {
       addressIndex += numAddressPerCall
     }
 
-    throw new Error('Not enough balance')
+    throw new Error('Not enough balance: getInputsForSweep')
   }
 
   async getInputsForAmount (_targets, _feePerByte, fixedInputs = [], numAddressPerCall = 100) {
@@ -422,6 +422,6 @@ export default superclass => class BitcoinWalletProvider extends superclass {
       addressIndex += numAddressPerCall
     }
 
-    throw new Error('Not enough balance')
+    throw new Error('Not enough balance: getInputsForAmount')
   }
 }

--- a/packages/bitcoin-wallet-provider/lib/BitcoinWalletProvider.js
+++ b/packages/bitcoin-wallet-provider/lib/BitcoinWalletProvider.js
@@ -51,12 +51,12 @@ export default superclass => class BitcoinWalletProvider extends superclass {
     return this._sendTransaction(transactions)
   }
 
-  async buildSweepTransaction (externalChangeAddress, outputs, feePerByte, fixedInputs) {
-    return this._buildSweepTransaction(externalChangeAddress, outputs, feePerByte, fixedInputs)
+  async buildSweepTransaction (externalChangeAddress, feePerByte, outputs, fixedInputs) {
+    return this._buildSweepTransaction(externalChangeAddress, feePerByte, outputs, fixedInputs)
   }
 
-  async sendSweepTransaction (externalChangeAddress, outputs, feePerByte, fixedInputs) {
-    const { hex, fee } = await this._buildSweepTransaction(externalChangeAddress, outputs, feePerByte, fixedInputs)
+  async sendSweepTransaction (externalChangeAddress, feePerByte, outputs, fixedInputs) {
+    const { hex, fee } = await this._buildSweepTransaction(externalChangeAddress, feePerByte, outputs, fixedInputs)
     await this.getMethod('sendRawTransaction')(hex)
     return normalizeTransactionObject(decodeRawTransaction(hex), fee)
   }

--- a/packages/bitcoin-wallet-provider/lib/BitcoinWalletProvider.js
+++ b/packages/bitcoin-wallet-provider/lib/BitcoinWalletProvider.js
@@ -51,12 +51,12 @@ export default superclass => class BitcoinWalletProvider extends superclass {
     return this._sendTransaction(transactions)
   }
 
-  async buildSweepTransaction (externalChangeAddress, feePerByte, outputs, fixedInputs) {
-    return this._buildSweepTransaction(externalChangeAddress, feePerByte, outputs, fixedInputs)
+  async buildSweepTransaction (externalChangeAddress, feePerByte) {
+    return this._buildSweepTransaction(externalChangeAddress, feePerByte)
   }
 
-  async sendSweepTransaction (externalChangeAddress, feePerByte, outputs, fixedInputs) {
-    const { hex, fee } = await this._buildSweepTransaction(externalChangeAddress, feePerByte, outputs, fixedInputs)
+  async sendSweepTransaction (externalChangeAddress, feePerByte) {
+    const { hex, fee } = await this._buildSweepTransaction(externalChangeAddress, feePerByte)
     await this.getMethod('sendRawTransaction')(hex)
     return normalizeTransactionObject(decodeRawTransaction(hex), fee)
   }

--- a/packages/bitcoin-wallet-provider/lib/BitcoinWalletProvider.js
+++ b/packages/bitcoin-wallet-provider/lib/BitcoinWalletProvider.js
@@ -292,7 +292,7 @@ export default superclass => class BitcoinWalletProvider extends superclass {
 
       const outputBalance = _targets.reduce((a, b) => a + (b['value'] || 0), 0)
 
-      const amountToSend = utxoBalance - (feePerByte * (((_targets.length + 1) * 45) + (utxos.length * 160))) // todo better calculation
+      const amountToSend = utxoBalance - (feePerByte * (((_targets.length + 1) * 40) + (utxos.length * 155))) // todo better calculation
 
       let targets = _targets.map((target, i) => ({ id: 'main', value: target.value }))
       targets.push({ id: 'main', value: amountToSend - outputBalance })

--- a/packages/client/lib/Chain.js
+++ b/packages/client/lib/Chain.js
@@ -189,26 +189,26 @@ export default class Chain {
 
   /**
    * Create & sign a sweep transaction
-   * @param {!string} externalChangeAddress - External Change address.
+   * @param {!string} externalAddress - External Change address.
    * @param {string[]} outputs - to, value.
    * @param {number} [fee] - Fee price in native unit (e.g. sat/b, wei)
    * @param {string[]} fixedInputs - txid, vout, address, value, satoshis, derivationPath
    * @return {Promise<string>} Resolves with a signed transaction object.
    */
-  async buildSweepTransaction (externalChangeAddress, outputs, fee, fixedInputs) {
-    return this.client.getMethod('buildSweepTransaction')(externalChangeAddress, outputs, fee, fixedInputs)
+  async buildSweepTransaction (externalAddress, fee, outputs, fixedInputs) {
+    return this.client.getMethod('buildSweepTransaction')(externalAddress, fee, outputs, fixedInputs)
   }
 
   /**
    * Create, sign & broadcast a sweep transaction.
-   * @param {!string} externalChangeAddress - External Change address.
+   * @param {!string} externalAddress - External Change address.
    * @param {string[]} outputs - to, value.
    * @param {number} [fee] - Fee price in native unit (e.g. sat/b, wei)
    * @param {string[]} fixedInputs - txid, vout, address, value, satoshis, derivationPath
    * @return {Promise<Transaction>} Resolves with a signed transaction.
    */
-  async sendSweepTransaction (externalChangeAddress, outputs, fee, fixedInputs) {
-    return this.client.getMethod('sendSweepTransaction')(externalChangeAddress, outputs, fee, fixedInputs)
+  async sendSweepTransaction (externalAddress, fee, outputs, fixedInputs) {
+    return this.client.getMethod('sendSweepTransaction')(externalAddress, fee, outputs, fixedInputs)
   }
 
   /**

--- a/packages/client/lib/Chain.js
+++ b/packages/client/lib/Chain.js
@@ -188,27 +188,13 @@ export default class Chain {
   }
 
   /**
-   * Create & sign a sweep transaction
-   * @param {!string} externalAddress - External Change address.
-   * @param {string[]} outputs - to, value.
-   * @param {number} [fee] - Fee price in native unit (e.g. sat/b, wei)
-   * @param {string[]} fixedInputs - txid, vout, address, value, satoshis, derivationPath
-   * @return {Promise<string>} Resolves with a signed transaction object.
-   */
-  async buildSweepTransaction (externalAddress, fee, outputs, fixedInputs) {
-    return this.client.getMethod('buildSweepTransaction')(externalAddress, fee, outputs, fixedInputs)
-  }
-
-  /**
    * Create, sign & broadcast a sweep transaction.
-   * @param {!string} externalAddress - External Change address.
-   * @param {string[]} outputs - to, value.
+   * @param {!string} address - External address.
    * @param {number} [fee] - Fee price in native unit (e.g. sat/b, wei)
-   * @param {string[]} fixedInputs - txid, vout, address, value, satoshis, derivationPath
    * @return {Promise<Transaction>} Resolves with a signed transaction.
    */
-  async sendSweepTransaction (externalAddress, fee, outputs, fixedInputs) {
-    return this.client.getMethod('sendSweepTransaction')(externalAddress, fee, outputs, fixedInputs)
+  async sendSweepTransaction (address, fee) {
+    return this.client.getMethod('sendSweepTransaction')(address, fee)
   }
 
   /**

--- a/packages/client/lib/Chain.js
+++ b/packages/client/lib/Chain.js
@@ -188,6 +188,30 @@ export default class Chain {
   }
 
   /**
+   * Create & sign a sweep transaction
+   * @param {!string} externalChangeAddress - External Change address.
+   * @param {string[]} outputs - to, value.
+   * @param {number} [fee] - Fee price in native unit (e.g. sat/b, wei)
+   * @param {string[]} fixedInputs - txid, vout, address, value, satoshis, derivationPath
+   * @return {Promise<string>} Resolves with a signed transaction object.
+   */
+  async buildSweepTransaction (externalChangeAddress, outputs, fee, fixedInputs) {
+    return this.client.getMethod('buildSweepTransaction')(externalChangeAddress, outputs, fee, fixedInputs)
+  }
+
+  /**
+   * Create, sign & broadcast a sweep transaction.
+   * @param {!string} externalChangeAddress - External Change address.
+   * @param {string[]} outputs - to, value.
+   * @param {number} [fee] - Fee price in native unit (e.g. sat/b, wei)
+   * @param {string[]} fixedInputs - txid, vout, address, value, satoshis, derivationPath
+   * @return {Promise<Transaction>} Resolves with a signed transaction.
+   */
+  async sendSweepTransaction (externalChangeAddress, outputs, fee, fixedInputs) {
+    return this.client.getMethod('sendSweepTransaction')(externalChangeAddress, outputs, fee, fixedInputs)
+  }
+
+  /**
    * Update the fee of a transaction.
    * @param {(string|Transaction)} tx - Transaction object or hash of the transaction to update
    * @param {!string} newFee - New fee price in native unit (e.g. sat/b, wei)

--- a/packages/ethereum-erc20-provider/lib/EthereumErc20Provider.js
+++ b/packages/ethereum-erc20-provider/lib/EthereumErc20Provider.js
@@ -51,6 +51,14 @@ export default class EthereumErc20Provider extends Provider {
     return this.getMethod('sendTransaction')(to, value, data, gasPrice)
   }
 
+  async sendSweepTransaction (address, gasPrice) {
+    const addresses = await this.getMethod('getAddresses')()
+
+    const balance = await this.getBalance(addresses)
+
+    return this.sendTransaction(address, balance, null, gasPrice)
+  }
+
   getContractAddress () {
     return this._contractAddress
   }

--- a/packages/ethereum-js-wallet-provider/lib/EthereumJsWalletProvider.js
+++ b/packages/ethereum-js-wallet-provider/lib/EthereumJsWalletProvider.js
@@ -106,7 +106,7 @@ export default class EthereumJsWalletProvider extends Provider {
     return normalizeTransactionObject(formatEthResponse(txData))
   }
 
-  async sendSweepTransaction (externalAddress, _gasPrice) {
+  async sendSweepTransaction (address, _gasPrice) {
     const addresses = await this.getAddresses()
 
     const balance = await this.getMethod('getBalance')(addresses)
@@ -118,7 +118,7 @@ export default class EthereumJsWalletProvider extends Provider {
     const fees = BigNumber(gasPrice).times(21000).times('1000000000')
     const amountToSend = BigNumber(balance).minus(fees)
 
-    return this.sendTransaction(externalAddress, amountToSend, null, gasPrice)
+    return this.sendTransaction(address, amountToSend, null, gasPrice)
   }
 
   async updateTransactionFee (tx, newGasPrice) {

--- a/packages/ethereum-js-wallet-provider/lib/EthereumJsWalletProvider.js
+++ b/packages/ethereum-js-wallet-provider/lib/EthereumJsWalletProvider.js
@@ -3,6 +3,7 @@ import { Address, addressToString } from '@liquality/utils'
 import { remove0x, buildTransaction, formatEthResponse, normalizeTransactionObject } from '@liquality/ethereum-utils'
 import { sha256 } from '@liquality/crypto'
 import { mnemonicToSeed } from 'bip39'
+import BigNumber from 'bignumber.js'
 import { fromMasterSeed } from 'hdkey'
 import * as ethUtil from 'ethereumjs-util'
 import { Transaction } from 'ethereumjs-tx'
@@ -103,6 +104,21 @@ export default class EthereumJsWalletProvider extends Provider {
     const txHash = await this.getMethod('sendRawTransaction')(serializedTx)
     txData.hash = txHash
     return normalizeTransactionObject(formatEthResponse(txData))
+  }
+
+  async sendSweepTransaction (externalAddress, _gasPrice) {
+    const addresses = await this.getAddresses()
+
+    const balance = await this.getMethod('getBalance')(addresses)
+
+    const [ gasPrice ] = await Promise.all([
+      _gasPrice ? Promise.resolve(_gasPrice) : this.getMethod('getGasPrice')()
+    ])
+
+    const fees = BigNumber(gasPrice).times(21000).times('1000000000')
+    const amountToSend = BigNumber(balance).minus(fees)
+
+    return this.sendTransaction(externalAddress, amountToSend, null, gasPrice)
   }
 
   async updateTransactionFee (tx, newGasPrice) {

--- a/test/integration/tx/bitcoin.js
+++ b/test/integration/tx/bitcoin.js
@@ -43,8 +43,17 @@ function testSweepTransaction (chain) {
     const changeAddresses = await chain.client.wallet.getAddresses(0, 20, true)
     const addrList = nonChangeAddresses.concat(changeAddresses)
 
-    await chain.client.chain.sendTransaction(changeAddresses[1], 200000000)
-    await chain.client.chain.sendTransaction(changeAddresses[2], 200000000)
+    const bal = parseInt(await chain.client.chain.getBalance(addrList))
+
+    let sendTxChain
+    if (bal === 0) {
+      sendTxChain = chains.bitcoinWithNode
+    } else {
+      sendTxChain = chain
+    }
+
+    await sendTxChain.client.chain.sendTransaction(changeAddresses[1], 200000000)
+    await sendTxChain.client.chain.sendTransaction(changeAddresses[2], 200000000)
 
     let testUtxos = await chain.client.getMethod('getUnspentTransactions')([changeAddresses[1]])
 
@@ -62,19 +71,33 @@ function testSweepTransaction (chain) {
     const addr1 = await getRandomBitcoinAddress(chain)
 
     await chain.client.getMethod('sendSweepTransaction')(addr1, [], false, fixedInputs)
+
+    const balanceAfter = await chain.client.chain.getBalance([changeAddresses[1]])
+    expect(balanceAfter.toString()).to.equal('0')
   })
 
   it('should sweep wallet balance', async () => {
     await fundWallet(chains.bitcoinWithJs)
 
+    const nonChangeAddresses = await chain.client.wallet.getAddresses(0, 20, false)
     const changeAddresses = await chain.client.wallet.getAddresses(0, 20, true)
+    const addrList = nonChangeAddresses.concat(changeAddresses)
 
-    await chain.client.chain.sendTransaction(changeAddresses[1], 200000000)
-    await chain.client.chain.sendTransaction(changeAddresses[2], 200000000)
-    await chain.client.chain.sendTransaction(changeAddresses[3], 200000000)
-    await chain.client.chain.sendTransaction(changeAddresses[4], 200000000)
-    await chain.client.chain.sendTransaction(changeAddresses[5], 200000000)
-    await chain.client.chain.sendTransaction(changeAddresses[6], 200000000)
+    const bal = parseInt(await chain.client.chain.getBalance(addrList))
+
+    let sendTxChain
+    if (bal === 0) {
+      sendTxChain = chains.bitcoinWithNode
+    } else {
+      sendTxChain = chain
+    }
+
+    await sendTxChain.client.chain.sendTransaction(changeAddresses[1], 200000000)
+    await sendTxChain.client.chain.sendTransaction(changeAddresses[2], 200000000)
+    await sendTxChain.client.chain.sendTransaction(changeAddresses[3], 200000000)
+    await sendTxChain.client.chain.sendTransaction(changeAddresses[4], 200000000)
+    await sendTxChain.client.chain.sendTransaction(changeAddresses[5], 200000000)
+    await sendTxChain.client.chain.sendTransaction(changeAddresses[6], 200000000)
 
     const addr1 = await getRandomBitcoinAddress(chain)
 
@@ -87,14 +110,25 @@ function testSweepTransaction (chain) {
   it('should sweep wallet balance and send funds to external change address', async () => {
     await fundWallet(chain)
 
+    const nonChangeAddresses = await chain.client.wallet.getAddresses(0, 20, false)
     const changeAddresses = await chain.client.wallet.getAddresses(0, 20, true)
+    const addrList = nonChangeAddresses.concat(changeAddresses)
 
-    await chain.client.chain.sendTransaction(changeAddresses[1], 200000000)
-    await chain.client.chain.sendTransaction(changeAddresses[2], 200000000)
-    await chain.client.chain.sendTransaction(changeAddresses[3], 200000000)
-    await chain.client.chain.sendTransaction(changeAddresses[4], 200000000)
-    await chain.client.chain.sendTransaction(changeAddresses[5], 200000000)
-    await chain.client.chain.sendTransaction(changeAddresses[6], 200000000)
+    const bal = parseInt(await chain.client.chain.getBalance(addrList))
+
+    let sendTxChain
+    if (bal === 0) {
+      sendTxChain = chains.bitcoinWithNode
+    } else {
+      sendTxChain = chain
+    }
+
+    await sendTxChain.client.chain.sendTransaction(changeAddresses[1], 200000000)
+    await sendTxChain.client.chain.sendTransaction(changeAddresses[2], 200000000)
+    await sendTxChain.client.chain.sendTransaction(changeAddresses[3], 200000000)
+    await sendTxChain.client.chain.sendTransaction(changeAddresses[4], 200000000)
+    await sendTxChain.client.chain.sendTransaction(changeAddresses[5], 200000000)
+    await sendTxChain.client.chain.sendTransaction(changeAddresses[6], 200000000)
 
     const addr1 = await getRandomBitcoinAddress(chain)
     const addr2 = await getRandomBitcoinAddress(chain)

--- a/test/integration/tx/bitcoin.js
+++ b/test/integration/tx/bitcoin.js
@@ -70,7 +70,7 @@ function testSweepTransaction (chain) {
 
     const addr1 = await getRandomBitcoinAddress(chain)
 
-    await chain.client.getMethod('sendSweepTransaction')(addr1, [], false, fixedInputs)
+    await chain.client.getMethod('sendSweepTransaction')(addr1, false, [], fixedInputs)
 
     const balanceAfter = await chain.client.chain.getBalance([changeAddresses[1]])
     expect(balanceAfter.toString()).to.equal('0')
@@ -133,7 +133,7 @@ function testSweepTransaction (chain) {
     const addr1 = await getRandomBitcoinAddress(chain)
     const addr2 = await getRandomBitcoinAddress(chain)
 
-    await chain.client.getMethod('sendSweepTransaction')(addr1, [{ to: addr2, value: 1000000 }])
+    await chain.client.getMethod('sendSweepTransaction')(addr1, false, [{ to: addr2, value: 1000000 }])
 
     const balanceAfter = await chain.client.chain.getBalance(changeAddresses)
     expect(balanceAfter.toString()).to.equal('0')

--- a/test/integration/tx/ethereum.js
+++ b/test/integration/tx/ethereum.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 /* eslint-disable no-unused-expressions */
-import chai from 'chai'
+import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'
-import { chains, fundWallet, describeExternal, connectMetaMask, deployERC20Token, stopEthAutoMining } from '../common'
+import { chains, fundWallet, describeExternal, connectMetaMask, deployERC20Token, stopEthAutoMining, getRandomAddress, mineBlock } from '../common'
 import { testTransaction } from './common'
 import config from '../config'
 
@@ -10,6 +10,23 @@ process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = 0
 
 chai.use(chaiAsPromised)
 chai.use(require('chai-bignumber')())
+
+function testSweepTransaction (chain) {
+  it('should sweep specific address', async () => {
+    const addr = await getRandomAddress(chain)
+
+    await chain.client.getMethod('sendSweepTransaction')(addr)
+
+    await mineBlock(chain)
+
+    const addresses = await chain.client.wallet.getAddresses()
+
+    const balAfter = await chain.client.chain.getBalance(addresses[0])
+    console.log('balAfter', parseInt(balAfter))
+
+    expect('0').to.equal(balAfter.toString())
+  })
+}
 
 describe('Transactions', function () {
   this.timeout(config.timeout)
@@ -25,6 +42,7 @@ describe('Transactions', function () {
       await fundWallet(chains.ethereumWithJs)
     })
     testTransaction(chains.ethereumWithJs)
+    testSweepTransaction(chains.ethereumWithJs)
   })
 
   describeExternal('Ethereum - Ledger', () => {

--- a/test/integration/tx/ethereum.js
+++ b/test/integration/tx/ethereum.js
@@ -73,6 +73,7 @@ describe('Transactions', function () {
       await deployERC20Token(chains.erc20WithJs)
     })
     testTransaction(chains.erc20WithJs)
+    testSweepTransaction(chains.erc20WithJs)
   })
 
   describeExternal('ERC20 - Ledger', () => {


### PR DESCRIPTION
### Description

This PR adds `buildSweepTransaction` and `sendSweepTransaction` for Bitcoin js wallet enabling the ability to sweep all utxos to a destination of choice. 

This is particularly useful if you wish to remove all funds from a wallet

Note: This can be useful for Ethereum as well. The major use case would be for sweeping all ETH from a wallet (since it's already pretty easy to do this for ERC20's)

### Submission Checklist :pencil:

- [x] Add `buildSweepTransaction
- [x] Add `sendSweepTransaction
- [x] Add tests for `sendSweepTransaction`