### PR TITLE
fix: make sure verifyInitiateSwapTransaction and findAddressTransacti…

### DIFF
--- a/packages/near-rpc-provider/lib/NearRpcProvider.ts
+++ b/packages/near-rpc-provider/lib/NearRpcProvider.ts
@@ -150,7 +150,8 @@ export default class NearRpcProvider extends NodeProvider implements Partial<Cha
               {
                 transaction: t,
                 blockNumber: header.height,
-                blockHash: header.hash
+                blockHash: header.hash,
+                status: t.status
               },
               currentHeight
             )

--- a/packages/near-swap-find-provider/lib/NearSwapFindProvider.ts
+++ b/packages/near-swap-find-provider/lib/NearSwapFindProvider.ts
@@ -109,6 +109,11 @@ export default class NearSwapFindProvider extends NodeProvider implements Partia
       const tx = Object.values(normalizedTransactions).find(predicate)
 
       if (tx) {
+        const txReceipt = await this.getMethod('getTransactionReceipt')(tx.hash)
+        if (!txReceipt || (txReceipt.status && txReceipt.status.Failure)) {
+          return
+        }
+
         const currentHeight = await this.getMethod('getBlockHeight')()
         const txBlockHeight = await this.getMethod('getBlockHeight')(tx.blockHash)
         tx.confirmations = currentHeight - txBlockHeight

--- a/packages/near-swap-provider/lib/NearSwapProvider.ts
+++ b/packages/near-swap-provider/lib/NearSwapProvider.ts
@@ -114,7 +114,8 @@ export default class NearSwapProvider extends Provider implements Partial<SwapPr
     }
 
     const parsedInitiationTx = parseReceipt(initiationTransaction)
-    return this.doesTransactionMatchInitiation(swapParams, parsedInitiationTx)
+    const txMatchInitiation = this.doesTransactionMatchInitiation(swapParams, parsedInitiationTx)
+    return txMatchInitiation && !parsedInitiationTx._raw.status.Failure
   }
 
   async getSwapSecret(claimTxHash: string): Promise<string> {
@@ -126,7 +127,7 @@ export default class NearSwapProvider extends Provider implements Partial<SwapPr
     return parsedTx.swap.secret
   }
 
-  generateUniqueString(prefix = 'liquality-htlc'): string {
-    return `${prefix}${Date.now() + Math.round(Math.random() * 1000)}`
+  generateUniqueString(prefix = 'liquality-wallet-htlc'): string {
+    return `${prefix}-${Date.now() + Math.round(Math.random() * 1000)}`
   }
 }

--- a/packages/near-swap-provider/lib/NearSwapProvider.ts
+++ b/packages/near-swap-provider/lib/NearSwapProvider.ts
@@ -20,7 +20,7 @@ export default class NearSwapProvider extends Provider implements Partial<SwapPr
 
   async initiateSwap(swapParams: SwapParams): Promise<Transaction<near.InputTransaction>> {
     const bytecode = this.createSwapScript()
-    const contractId = this.generateUniqueString()
+    const contractId = this.generateUniqueString(swapParams.secretHash.substr(0, 20))
 
     return this.client.chain.sendTransaction({
       to: contractId,
@@ -127,7 +127,7 @@ export default class NearSwapProvider extends Provider implements Partial<SwapPr
     return parsedTx.swap.secret
   }
 
-  generateUniqueString(prefix = 'liquality-wallet-htlc'): string {
-    return `${prefix}-${Date.now() + Math.round(Math.random() * 1000)}`
+  generateUniqueString(name: string): string {
+    return `htlc-${name}-${Date.now() + Math.round(Math.random() * 1000)}`
   }
 }

--- a/packages/types/lib/near/index.ts
+++ b/packages/types/lib/near/index.ts
@@ -12,6 +12,7 @@ export interface Tx {
   actions: any[]
   signature: string
   hash: string
+  status: ExecutionStatus
   blockNumber?: number
 }
 
@@ -35,10 +36,22 @@ export interface NearBlockHeader {
   transactions: NormalizedTransaction[]
 }
 
+interface ExecutionError {
+  error_message: string
+  error_type: string
+}
+
+interface ExecutionStatus {
+  SuccessValue?: string
+  SuccessReceiptId?: string
+  Failure?: ExecutionError
+}
+
 export interface InputTransaction {
   transaction: Tx
   blockNumber: number
   blockHash: string
+  status: ExecutionStatus
 }
 
 export interface NormalizedTransaction {


### PR DESCRIPTION
### Description

- `verifyInitiateSwapTransaction` and `findAddressTransaction` methods now consider the tx status (i.e. handles correctly failed transactions)
- `contractId` used to create the HTLC contract is now more than 32 chars long. That was required due to:
```
"kind": {
      "CreateAccountOnlyByRegistrar": {
        "account_id": "liquality-htlc1620768264472",
        "registrar_account_id": "registrar",
        "predecessor_id": "4e9c6a0a33df221a1c737b7ebb56528b4d637be555bb7c66c7287369e4299b69"
      }
    }
```
Read more here: https://nomicon.io/DataStructures/Account.html#top-level-accounts