### PR TITLE
Near swap validation

### DIFF
--- a/packages/ethereum-swap-provider/lib/EthereumSwapProvider.ts
+++ b/packages/ethereum-swap-provider/lib/EthereumSwapProvider.ts
@@ -152,7 +152,6 @@ export default class EthereumSwapProvider extends Provider implements Partial<Sw
   }
 
   async claimSwap(swapParams: SwapParams, initiationTxHash: string, secret: string, gasPrice: number) {
-    this.validateSwapParams(swapParams)
     validateSecret(secret)
     validateSecretAndHash(secret, swapParams.secretHash)
     await this.verifyInitiateSwapTransaction(swapParams, initiationTxHash)
@@ -172,7 +171,6 @@ export default class EthereumSwapProvider extends Provider implements Partial<Sw
   }
 
   async refundSwap(swapParams: SwapParams, initiationTxHash: string, gasPrice: number) {
-    this.validateSwapParams(swapParams)
     await this.verifyInitiateSwapTransaction(swapParams, initiationTxHash)
 
     const initiationTransactionReceipt = await this.getMethod('getTransactionReceipt')(initiationTxHash)

--- a/packages/near-swap-find-provider/lib/NearSwapFindProvider.ts
+++ b/packages/near-swap-find-provider/lib/NearSwapFindProvider.ts
@@ -2,7 +2,7 @@ import { near, SwapParams, SwapProvider, Transaction } from '@liquality/types'
 import { NodeProvider } from '@liquality/node-provider'
 import { PendingTxError } from '@liquality/errors'
 import { addressToString } from '@liquality/utils'
-import { fromBase64, toBase64, fromNearTimestamp, parseReceipt } from '@liquality/near-utils'
+import { fromBase64, toBase64, fromNearTimestamp, parseReceipt, validateSwapParams } from '@liquality/near-utils'
 
 const ONE_DAY_IN_NS = 24 * 60 * 60 * 1000 * 1000 * 1000
 
@@ -125,6 +125,8 @@ export default class NearSwapFindProvider extends NodeProvider implements Partia
   }
 
   async findInitiateSwapTransaction(swapParams: SwapParams) {
+    validateSwapParams(swapParams)
+
     return this.findAddressTransaction(addressToString(swapParams.refundAddress), (tx: near.NearSwapTransaction) =>
       this.getMethod('doesTransactionMatchInitiation')(swapParams, tx)
     )
@@ -134,8 +136,9 @@ export default class NearSwapFindProvider extends NodeProvider implements Partia
     swapParams: SwapParams,
     initiationTxHash: string
   ): Promise<Transaction<near.NearSwapTransaction>> {
-    const initiationTransactionReceipt = await this.getMethod('getTransactionReceipt')(initiationTxHash)
+    validateSwapParams(swapParams)
 
+    const initiationTransactionReceipt = await this.getMethod('getTransactionReceipt')(initiationTxHash)
     if (!initiationTransactionReceipt) {
       throw new PendingTxError(`Transaction receipt is not available: ${initiationTxHash}`)
     }
@@ -158,8 +161,9 @@ export default class NearSwapFindProvider extends NodeProvider implements Partia
     swapParams: SwapParams,
     initiationTxHash: string
   ): Promise<Transaction<near.NearSwapTransaction>> {
-    const initiationTransactionReceipt = await this.getMethod('getTransactionReceipt')(initiationTxHash)
+    validateSwapParams(swapParams)
 
+    const initiationTransactionReceipt = await this.getMethod('getTransactionReceipt')(initiationTxHash)
     if (!initiationTransactionReceipt) {
       throw new PendingTxError(`Transaction receipt is not available: ${initiationTxHash}`)
     }

--- a/packages/near-swap-find-provider/lib/NearSwapFindProvider.ts
+++ b/packages/near-swap-find-provider/lib/NearSwapFindProvider.ts
@@ -2,7 +2,14 @@ import { near, SwapParams, SwapProvider, Transaction } from '@liquality/types'
 import { NodeProvider } from '@liquality/node-provider'
 import { PendingTxError } from '@liquality/errors'
 import { addressToString } from '@liquality/utils'
-import { fromBase64, toBase64, fromNearTimestamp, parseReceipt, validateSwapParams } from '@liquality/near-utils'
+import {
+  fromBase64,
+  toBase64,
+  fromNearTimestamp,
+  parseReceipt,
+  validateSwapParams,
+  validateSecretAndHash
+} from '@liquality/near-utils'
 
 const ONE_DAY_IN_NS = 24 * 60 * 60 * 1000 * 1000 * 1000
 
@@ -153,6 +160,7 @@ export default class NearSwapFindProvider extends NodeProvider implements Partia
     )
 
     if (tx && tx.secret) {
+      validateSecretAndHash(tx.secret, swapParams.secretHash)
       return tx
     }
   }

--- a/packages/near-swap-provider/test/unit/index.test.ts
+++ b/packages/near-swap-provider/test/unit/index.test.ts
@@ -1,0 +1,158 @@
+/* eslint-env mocha */
+import { BigNumber } from '@liquality/types'
+import { NearSwapProvider } from '../../lib'
+
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+
+const { expect } = chai.use(chaiAsPromised)
+
+describe('Near Swap provider', () => {
+  let provider: NearSwapProvider
+
+  beforeEach(() => {
+    provider = new NearSwapProvider()
+  })
+
+  describe('Generate swap', async () => {
+    describe('Swap contract address validation', async () => {
+      async function testRecipientAddress(recipientAddress: string) {
+        return expect(() =>
+          provider.initiateSwap({
+            value: new BigNumber(111),
+            recipientAddress,
+            refundAddress: '0a81e8be41b21f651a71aab1a85c6813b8bbccf8',
+            secretHash: 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+            expiration: 1468194353
+          })
+        )
+          .to.throw()
+          .property('name', 'InvalidAddressError')
+      }
+
+      async function testRefundAddress(refundAddress: string) {
+        return expect(() =>
+          provider.initiateSwap({
+            value: new BigNumber(111),
+            recipientAddress: '0a81e8be41b21f651a71aab1a85c6813b8bbccf8',
+            refundAddress,
+            secretHash: 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+            expiration: 1468194353
+          })
+        )
+          .to.throw()
+          .property('name', 'InvalidAddressError')
+      }
+
+      it('should throw error with address wrong type', async () => {
+        // @ts-ignore
+        testRecipientAddress(123)
+        // @ts-ignore
+        testRefundAddress(123)
+      })
+
+      it('should throw error with address too short', () => {
+        testRecipientAddress('1')
+        testRefundAddress('1')
+      })
+
+      it('should throw error with address too long', () => {
+        testRecipientAddress('0a81e8be41b21f651a71aab1a85c6813b8bbccf88888888888888888888888888')
+        testRefundAddress('0a81e8be41b21f651a71aab1a85c6813b8bbccf88888888888888888888888888')
+      })
+    })
+
+    describe('Swap contract secretHash validation', () => {
+      async function testSecretHash(secretHash: string) {
+        return expect(() =>
+          provider.initiateSwap({
+            value: new BigNumber(111),
+            recipientAddress: '5acbf79d0cf4139a6c3eca85b41ce2bd23ced04f',
+            refundAddress: '0a81e8be41b21f651a71aab1a85c6813b8bbccf8',
+            secretHash,
+            expiration: 1468194353
+          })
+        )
+          .to.throw()
+          .property('name', 'InvalidSecretError')
+      }
+
+      it('should throw when secretHash too small', () => {
+        testSecretHash('ffff')
+      })
+
+      it('should throw when secretHash too large', () => {
+        testSecretHash('ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')
+      })
+
+      it('should throw when secretHash not hex', () => {
+        testSecretHash('OPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOP')
+      })
+
+      it('should throw error when secret hash is hash of secret 0', () => {
+        testSecretHash('66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925')
+      })
+    })
+
+    describe('Swap contract expiration validation', () => {
+      async function testExpirationInvalid(expiration: number) {
+        return expect(() =>
+          provider.initiateSwap({
+            value: new BigNumber(111),
+            recipientAddress: '5acbf79d0cf4139a6c3eca85b41ce2bd23ced04f',
+            refundAddress: '0a81e8be41b21f651a71aab1a85c6813b8bbccf8',
+            secretHash: 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+            expiration
+          })
+        )
+          .to.throw()
+          .property('name', 'InvalidExpirationError')
+      }
+
+      it('should throw error with 0 expiration', () => {
+        testExpirationInvalid(0)
+      })
+
+      it('should throw error with expiration too small', () => {
+        testExpirationInvalid(5000000)
+      })
+
+      it('should throw error with expiration too big', () => {
+        testExpirationInvalid(1234567891234567)
+      })
+
+      it('should throw error with expiration not number', () => {
+        // @ts-ignore
+        testExpirationInvalid('123')
+      })
+    })
+
+    describe('Swap contract secretHash validation', () => {
+      async function testSecretHash(secretHash: string) {
+        return expect(() =>
+          provider.initiateSwap({
+            value: new BigNumber(111),
+            recipientAddress: '5acbf79d0cf4139a6c3eca85b41ce2bd23ced04f',
+            refundAddress: '0a81e8be41b21f651a71aab1a85c6813b8bbccf8',
+            secretHash,
+            expiration: 1468194353
+          })
+        )
+          .to.throw()
+          .property('name', 'InvalidSecretError')
+      }
+
+      it('should throw when secretHash too small', () => {
+        testSecretHash('ffff')
+      })
+
+      it('should throw when secretHash too large', () => {
+        testSecretHash('ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')
+      })
+
+      it('should throw when secretHash not hex', () => {
+        testSecretHash('OPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOPOP')
+      })
+    })
+  })
+})

--- a/packages/near-utils/lib/index.ts
+++ b/packages/near-utils/lib/index.ts
@@ -1,6 +1,6 @@
-import { near, SwapParams, Transaction } from '@liquality/types'
-import { validateValue, validateSecretHash, validateExpiration } from '@liquality/utils'
-
+import { near, SwapParams, Transaction, Address } from '@liquality/types'
+import { validateValue, validateSecretHash, validateExpiration, addressToString } from '@liquality/utils'
+import { InvalidAddressError } from '@liquality/errors'
 import BN from 'bn.js'
 
 export { validateSecret, validateSecretAndHash } from '@liquality/utils'
@@ -9,8 +9,26 @@ export { BN }
 
 export function validateSwapParams(swapParams: SwapParams) {
   validateValue(swapParams.value)
+  validateAddress(swapParams.recipientAddress)
+  validateAddress(swapParams.refundAddress)
   validateSecretHash(swapParams.secretHash)
   validateExpiration(swapParams.expiration)
+}
+
+export function validateAddress(_address: Address | string) {
+  const address = addressToString(_address)
+
+  if (typeof address !== 'string') {
+    throw new InvalidAddressError(`Invalid address: ${address}`)
+  }
+
+  if (address.length < 2) {
+    throw new InvalidAddressError(`Invalid address. Minimum length is 2`)
+  }
+
+  if (address.length > 64) {
+    throw new InvalidAddressError(`Invalid address. Maximum length is 64`)
+  }
 }
 
 function toBase64(str: string, encoding = 'hex' as BufferEncoding): string {

--- a/packages/near-utils/lib/index.ts
+++ b/packages/near-utils/lib/index.ts
@@ -1,8 +1,17 @@
-import { near, Transaction } from '@liquality/types'
+import { near, SwapParams, Transaction } from '@liquality/types'
+import { validateValue, validateSecretHash, validateExpiration } from '@liquality/utils'
+
 import BN from 'bn.js'
 
+export { validateSecret, validateSecretAndHash } from '@liquality/utils'
 export { transactions, Account, InMemorySigner, providers, KeyPair, keyStores } from 'near-api-js'
 export { BN }
+
+export function validateSwapParams(swapParams: SwapParams) {
+  validateValue(swapParams.value)
+  validateSecretHash(swapParams.secretHash)
+  validateExpiration(swapParams.expiration)
+}
 
 function toBase64(str: string, encoding = 'hex' as BufferEncoding): string {
   try {

--- a/packages/near-utils/package.json
+++ b/packages/near-utils/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@babel/runtime": "^7.12.1",
     "@liquality/types": "^1.1.5",
+    "@liquality/utils": "^1.1.5",
     "bn.js": "^5.2.0",
     "near-api-js": "^0.39.0"
   },

--- a/packages/near-utils/package.json
+++ b/packages/near-utils/package.json
@@ -20,6 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.12.1",
+    "@liquality/errors": "^1.1.5",
     "@liquality/types": "^1.1.5",
     "@liquality/utils": "^1.1.5",
     "bn.js": "^5.2.0",


### PR DESCRIPTION
### Description

- remove `validateSwapParams` from claimSwap and `refundSwap` because it's called inside `verifyInitiateSwapTransaction` 
- add swap params validation for Near
