### PR TITLE
fix: ETH privateKey format

### DIFF
--- a/packages/ethereum-js-wallet-provider/lib/EthereumJsWalletProvider.ts
+++ b/packages/ethereum-js-wallet-provider/lib/EthereumJsWalletProvider.ts
@@ -52,8 +52,8 @@ export default class EthereumJsWalletProvider extends WalletProvider {
   }
 
   async exportPrivateKey() {
-    const key = await this.hdKey()
-    return JSON.stringify(key.toJSON())
+    const { privateKey } = await this.hdKey()
+    return privateKey.toString('hex')
   }
 
   async signMessage(message: string) {

--- a/packages/types/lib/wallet.ts
+++ b/packages/types/lib/wallet.ts
@@ -60,7 +60,7 @@ export interface WalletProvider {
   /**
    * Exports the private key for the account
    * for BTC, https://en.bitcoin.it/wiki/Wallet_import_format
-   * for ETH, xpub/xpriv as JSON
+   * for ETH, the privateKey
    * for NEAR, the secretKey
    * @return {Promise<string>} Resolves with the key as a string
    */

--- a/test/integration/config.ts
+++ b/test/integration/config.ts
@@ -31,7 +31,7 @@ export default {
       chainId: 1337, // Default geth dev mode - * Needs to be <= 255 for ledger * https://github.com/ethereum/go-ethereum/issues/21120
       networkId: 1337
     },
-    privKeyRx: /"xpriv":\s*"xprv/,
+    privKeyRx: /\w{64}/,
     metaMaskConnector: {
       port: 3333
     }


### PR DESCRIPTION
before: `exportPrivateKey` would return xpriv/xpub json for ETH
after: `exportPrivateKey` returns 64-character privateKey string that I confirmed is importable into metamask.