### PR TITLE
feat: add jsonrpc version in JsonRpcProvider

### DIFF
--- a/packages/jsonrpc-provider/lib/JsonRpcProvider.ts
+++ b/packages/jsonrpc-provider/lib/JsonRpcProvider.ts
@@ -27,7 +27,8 @@ export default class JsonRpcProvider extends NodeProvider {
 
   _prepareRequest(method: string, params: any[]) {
     const id = Date.now()
-    const req = { id, method, params }
+    const jsonrpc = '2.0'
+    const req = { id, method, jsonrpc, params }
 
     debug('jsonrpc request', req)
 


### PR DESCRIPTION
### Description
Liquality omits the jsonrpc version which is a required parameter in openethereum nodes.

in openethereum nodes, we get this error if the jsonrpc version is not provided: `Unsupported JSON-RPC protocol version.`

## Fix
added jsonrpc version 2.0 to request parameter in the JsonRpcProvider class.