### PR TITLE
fix: Handle terra tx status

### DIFF
--- a/packages/terra-swap-provider/lib/TerraSwapProvider.ts
+++ b/packages/terra-swap-provider/lib/TerraSwapProvider.ts
@@ -93,14 +93,16 @@ export default class TerraSwapProvider extends Provider implements Partial<SwapP
     if (!initTx) {
       throw new TxNotFoundError(`Transaction not found: ${initiationTxHash}`)
     }
-
-    if (!doesTransactionMatchInitiation(swapParams, initTx._raw)) {
-      throw new StandardError('Transactions are not matching')
-    }
-
+    
     if (isTxError(initTx)) {
       throw new StandardError(`Encountered an error while running the transaction: ${initTx.code} ${initTx.codespace}`)
     }
+
+    if (!doesTransactionMatchInitiation(swapParams, initTx['_raw'])) {
+      throw new StandardError('Transactions are not matching')
+    }
+
+    
 
     return true
   }

--- a/packages/terra-swap-provider/lib/TerraSwapProvider.ts
+++ b/packages/terra-swap-provider/lib/TerraSwapProvider.ts
@@ -26,7 +26,7 @@ export default class TerraSwapProvider extends Provider implements Partial<SwapP
     return transaction?.secret
   }
 
-  async initiateSwap(swapParams: SwapParams, fee: any): Promise<Transaction<terra.InputTransaction>> {
+  async initiateSwap(swapParams: SwapParams, fee: number): Promise<Transaction<terra.InputTransaction>> {
     validateSwapParams(swapParams)
 
     const initContractMsg = this._instantiateContractMessage(swapParams)

--- a/packages/terra-swap-provider/lib/TerraSwapProvider.ts
+++ b/packages/terra-swap-provider/lib/TerraSwapProvider.ts
@@ -4,7 +4,7 @@ import { TxNotFoundError, StandardError } from '@liquality/errors'
 import { validateSwapParams, doesTransactionMatchInitiation } from '@liquality/terra-utils'
 import { validateSecretAndHash } from '@liquality/utils'
 import { TerraNetwork } from '@liquality/terra-networks'
-import { MsgExecuteContract, MsgInstantiateContract } from '@terra-money/terra.js'
+import { isTxError, MsgExecuteContract, MsgInstantiateContract } from '@terra-money/terra.js'
 
 export default class TerraSwapProvider extends Provider implements Partial<SwapProvider> {
   private _network: TerraNetwork
@@ -95,6 +95,10 @@ export default class TerraSwapProvider extends Provider implements Partial<SwapP
 
     if (!doesTransactionMatchInitiation(swapParams, initTx._raw)) {
       throw new StandardError('Transactions are not matching')
+    }
+
+    if (isTxError(initTx)) {
+      throw new StandardError(`Encountered an error while running the transaction: ${initTx.code} ${initTx.codespace}`)
     }
 
     return true

--- a/packages/terra-swap-provider/lib/TerraSwapProvider.ts
+++ b/packages/terra-swap-provider/lib/TerraSwapProvider.ts
@@ -26,14 +26,15 @@ export default class TerraSwapProvider extends Provider implements Partial<SwapP
     return transaction?.secret
   }
 
-  async initiateSwap(swapParams: SwapParams): Promise<Transaction<terra.InputTransaction>> {
+  async initiateSwap(swapParams: SwapParams, fee: any): Promise<Transaction<terra.InputTransaction>> {
     validateSwapParams(swapParams)
 
     const initContractMsg = this._instantiateContractMessage(swapParams)
 
     return await this.getMethod('sendTransaction')({
       data: {
-        msgs: [initContractMsg]
+        msgs: [initContractMsg],
+        fee
       }
     })
   }

--- a/packages/terra-swap-provider/lib/TerraSwapProvider.ts
+++ b/packages/terra-swap-provider/lib/TerraSwapProvider.ts
@@ -93,7 +93,7 @@ export default class TerraSwapProvider extends Provider implements Partial<SwapP
     if (!initTx) {
       throw new TxNotFoundError(`Transaction not found: ${initiationTxHash}`)
     }
-    
+
     if (isTxError(initTx)) {
       throw new StandardError(`Encountered an error while running the transaction: ${initTx.code} ${initTx.codespace}`)
     }
@@ -101,8 +101,6 @@ export default class TerraSwapProvider extends Provider implements Partial<SwapP
     if (!doesTransactionMatchInitiation(swapParams, initTx['_raw'])) {
       throw new StandardError('Transactions are not matching')
     }
-
-    
 
     return true
   }

--- a/packages/terra-wallet-provider/lib/TerraWalletProvider.ts
+++ b/packages/terra-wallet-provider/lib/TerraWalletProvider.ts
@@ -110,7 +110,7 @@ export default class TerraWalletProvider extends WalletProvider {
 
     if (isTxError(transaction)) {
       throw new Error(
-        `encountered an error while running the transaction: ${transaction.code} ${transaction.codespace} ${transaction.raw_log}`
+        `Encountered an error while running the transaction: ${transaction.code} ${transaction.codespace} ${transaction.raw_log}`
       )
     }
 
@@ -200,15 +200,12 @@ export default class TerraWalletProvider extends WalletProvider {
       const gasPrice = data.fee as any
       const gasLimit = 800000
 
-      const fee = ceil(new BigNumber(gasLimit).times(gasPrice).toNumber());
-      const coins = new Coins({[this._feeAsset]: fee})
-      
+      const fee = ceil(new BigNumber(gasLimit).times(gasPrice).toNumber())
+      const coins = new Coins({ [this._feeAsset]: fee })
+
       txData = {
         ...(data.fee && {
-          fee: new Fee(
-            gasLimit,
-            coins
-          )
+          fee: new Fee(gasLimit, coins)
         })
       }
     } else {

--- a/packages/terra-wallet-provider/lib/TerraWalletProvider.ts
+++ b/packages/terra-wallet-provider/lib/TerraWalletProvider.ts
@@ -105,7 +105,9 @@ export default class TerraWalletProvider extends WalletProvider {
 
   async sendTransaction(sendOptions: SendOptions): Promise<Transaction<terra.InputTransaction>> {
     const txData = this.composeTransaction(sendOptions)
+
     const tx = await this._wallet.createAndSignTx(txData)
+
     const transaction = await this._broadcastTx(tx)
 
     if (isTxError(transaction)) {


### PR DESCRIPTION
Handle transaction after broadcast on init, if there is any error transaction will be reverted and htlc wont be initialized. Add error handler before claim and refund transaction to check if status of init transaction is success or failure. Set fee when user init swap