### PR TITLE
Fix: Compare transaction lamports againts swapParams value

### DIFF
--- a/packages/solana-swap-provider/lib/SolanaSwapProvider.ts
+++ b/packages/solana-swap-provider/lib/SolanaSwapProvider.ts
@@ -130,7 +130,7 @@ export default class SolanaSwapProvider extends Provider implements Partial<Swap
   }
 
   async verifyInitiateSwapTransaction(swapParams: SwapParams, initiationTxHash: string): Promise<boolean> {
-    const [initTransaction] = await this.getMethod('getTransactionReceipt')([initiationTxHash])
+    const initTransaction = await this.getMethod('getTransactionByHash')(initiationTxHash)
 
     if (initTransaction.status !== TxStatus.Success) {
       throw new StandardError(`Status for transaction ${initiationTxHash} is ${initTransaction.status}`)

--- a/packages/solana-utils/lib/index.ts
+++ b/packages/solana-utils/lib/index.ts
@@ -190,7 +190,8 @@ export function normalizeTransaction(
     ...(transactionData.confirmations && { confirmations: transactionData.confirmations }),
     _raw: {
       programId: transactionData.programId,
-      ...transactionData._raw
+      ...transactionData._raw,
+      value: new BigNumber(transactionData.lamports)
     }
   }
 }


### PR DESCRIPTION
Check if transaction lamports are equal to swap params.value when we are comparing transactions. That way we are using the real provided lamport value when user is creating a htlc and not the passed one in init params