### PR TITLE
fix: Return 0 when balance is undefined and fix tx confirmations

### DIFF
--- a/packages/terra-rpc-provider/lib/TerraRpcProvider.ts
+++ b/packages/terra-rpc-provider/lib/TerraRpcProvider.ts
@@ -98,7 +98,7 @@ export default class TerraRpcProvider extends NodeProvider implements FeeProvide
             balance = Number(token.balance)
           } else {
             const coins = await this._lcdClient.bank.balance(address)
-            balance = Number(coins[0].get(this._asset)?.amount)
+            balance = Number(coins[0].get(this._asset)?.amount) || 0
           }
 
           return new BigNumber(balance)

--- a/packages/terra-utils/lib/index.ts
+++ b/packages/terra-utils/lib/index.ts
@@ -57,12 +57,7 @@ export const normalizeTransaction = (
       .value ||
     ''
 
-  let status
-  if (currentBlock - data.height < 10) {
-    status = TxStatus.Pending
-  } else {
-    status = data.raw_log?.includes('failed to execute message') ? TxStatus.Failed : TxStatus.Success
-  }
+  const status = data.raw_log?.includes('failed to execute message') ? TxStatus.Failed : TxStatus.Success
 
   return {
     value: Number(value),


### PR DESCRIPTION
This will fix:
[Fix transaction status](https://linear.app/liquality/issue/LIQ-999/terra-send-transactions-was-successful-on-terra-explorer-but-on-wallet)
[NaN when balance is 0](https://linear.app/liquality/issue/LIQ-1003/terra-balance-showing-as-nan-on-overview-screen)