### PR TITLE
fix: move NFTAsset type to global level

### DIFF
--- a/packages/client/lib/Nft.ts
+++ b/packages/client/lib/Nft.ts
@@ -1,4 +1,4 @@
-import { AddressType, BigNumber, FeeType, Transaction } from '@chainify/types';
+import { AddressType, BigNumber, FeeType, NFTAsset, Transaction } from '@chainify/types';
 import Wallet from './Wallet';
 
 export default abstract class Nft<T, S> {
@@ -33,5 +33,5 @@ export default abstract class Nft<T, S> {
 
     public abstract isApprovedForAll(contract: AddressType, operator: AddressType): Promise<boolean>;
 
-    public abstract fetch(): void;
+    public abstract fetch(): Promise<NFTAsset[]>;
 }

--- a/packages/evm/lib/nft/CovalentNftProvider.ts
+++ b/packages/evm/lib/nft/CovalentNftProvider.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from '@chainify/client';
+import { NFTAsset } from '@chainify/types';
 import { BaseProvider } from '@ethersproject/providers';
-import { NFTAsset, NftProviderConfig, NftTypes } from '../types';
+import { NftProviderConfig, NftTypes } from '../types';
 import { EvmBaseWalletProvider } from '../wallet/EvmBaseWalletProvider';
 import { EvmNftProvider } from './EvmNftProvider';
 

--- a/packages/evm/lib/nft/EvmNftProvider.ts
+++ b/packages/evm/lib/nft/EvmNftProvider.ts
@@ -1,11 +1,11 @@
 import { Nft } from '@chainify/client';
 import { UnsupportedMethodError } from '@chainify/errors';
-import { AddressType, BigNumber, FeeType, Transaction } from '@chainify/types';
+import { AddressType, BigNumber, FeeType, NFTAsset, Transaction } from '@chainify/types';
 import { Signer } from '@ethersproject/abstract-signer';
 import { AddressZero } from '@ethersproject/constants';
 import { BaseProvider } from '@ethersproject/providers';
 import { ERC1155, ERC1155__factory, ERC721, ERC721__factory } from '../typechain';
-import { EthersPopulatedTransaction, EthersTransactionResponse, NFTAsset, NftTypes } from '../types';
+import { EthersPopulatedTransaction, EthersTransactionResponse, NftTypes } from '../types';
 import { toEthereumTxRequest } from '../utils';
 import { EvmBaseWalletProvider } from '../wallet/EvmBaseWalletProvider';
 

--- a/packages/evm/lib/nft/MoralisNftProvider.ts
+++ b/packages/evm/lib/nft/MoralisNftProvider.ts
@@ -1,6 +1,7 @@
+import { NFTAsset } from '@chainify/types';
 import { BaseProvider } from '@ethersproject/providers';
 import Moralis from 'moralis/node';
-import { MoralisConfig, NFTAsset, NftTypes } from '../types';
+import { MoralisConfig, NftTypes } from '../types';
 import { EvmBaseWalletProvider } from '../wallet/EvmBaseWalletProvider';
 import { EvmNftProvider } from './EvmNftProvider';
 

--- a/packages/evm/lib/nft/OpenSeaNftProvider.ts
+++ b/packages/evm/lib/nft/OpenSeaNftProvider.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from '@chainify/client';
+import { NFTAsset } from '@chainify/types';
 import { BaseProvider } from '@ethersproject/providers';
-import { NFTAsset, NftProviderConfig, NftTypes } from '../types';
+import { NftProviderConfig, NftTypes } from '../types';
 import { EvmBaseWalletProvider } from '../wallet/EvmBaseWalletProvider';
 import { EvmNftProvider } from './EvmNftProvider';
 

--- a/packages/evm/lib/types.ts
+++ b/packages/evm/lib/types.ts
@@ -42,27 +42,6 @@ export type EthereumFeeData = FeeType & {
 
 export { EthersTransactionResponse, EthersBlock, EthersBlockWithTransactions, EthersPopulatedTransaction };
 
-export interface NFTAsset {
-    token_id: string;
-    asset_contract: {
-        address: string;
-        name: string;
-        symbol: string;
-        image_url?: string;
-        external_link?: string;
-    };
-    collection: {
-        name: string;
-    };
-    id?: number;
-    description?: string;
-    external_link?: string;
-    image_original_url?: string;
-    image_preview_url?: string;
-    image_thumbnail_url?: string;
-    name?: string;
-}
-
 export enum NftTypes {
     ERC721 = 'ERC721',
     ERC1155 = 'ERC1155',

--- a/packages/types/lib/Nft.ts
+++ b/packages/types/lib/Nft.ts
@@ -1,0 +1,20 @@
+export interface NFTAsset {
+    token_id: string;
+    asset_contract: {
+        address: string;
+        name: string;
+        symbol: string;
+        image_url?: string;
+        external_link?: string;
+    };
+    collection: {
+        name: string;
+    };
+    id?: number;
+    description?: string;
+    external_link?: string;
+    image_original_url?: string;
+    image_preview_url?: string;
+    image_thumbnail_url?: string;
+    name?: string;
+}

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -7,7 +7,7 @@ export * from './Block';
 export * from './Chain';
 export * from './Fees';
 export * from './Network';
-export * from './NFT';
+export * from './Nft';
 export * from './Swap';
 export * from './Transaction';
 export * from './Wallet';

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -7,6 +7,7 @@ export * from './Block';
 export * from './Chain';
 export * from './Fees';
 export * from './Network';
+export * from './NFT';
 export * from './Swap';
 export * from './Transaction';
 export * from './Wallet';


### PR DESCRIPTION
Move the nft asset to global level so that calling `client.nft.fetch` is correctly typed.