### PR TITLE
fix: replace toString with toFixed to prevent exponent error

### DIFF
--- a/packages/evm/lib/utils.ts
+++ b/packages/evm/lib/utils.ts
@@ -28,7 +28,7 @@ export function toEthereumTxRequest(tx: EthersPopulatedTransaction, fee: FeeType
 
 export function parseSwapParams(tx: SwapParams): ILiqualityHTLC.HTLCDataStruct {
     return {
-        amount: tx.value.toFixed(),
+        amount: tx.value.toString(10),
         expiration: tx.expiration,
         secretHash: ensure0x(tx.secretHash),
         tokenAddress: ensure0x(tx.asset.isNative ? AddressZero : tx.asset.contractAddress),

--- a/packages/evm/lib/utils.ts
+++ b/packages/evm/lib/utils.ts
@@ -28,7 +28,7 @@ export function toEthereumTxRequest(tx: EthersPopulatedTransaction, fee: FeeType
 
 export function parseSwapParams(tx: SwapParams): ILiqualityHTLC.HTLCDataStruct {
     return {
-        amount: tx.value.toString(),
+        amount: tx.value.toFixed(),
         expiration: tx.expiration,
         secretHash: ensure0x(tx.secretHash),
         tokenAddress: ensure0x(tx.asset.isNative ? AddressZero : tx.asset.contractAddress),


### PR DESCRIPTION
Fix for exponent number issues.

[LIQ-1446](https://linear.app/liquality/issue/LIQ-1446/as-a-user-i-want-to-be-able-to-swap-greater-than-1000-matic)