### PR TITLE
Fix: Update nft when swap changes & vise-versa

### DIFF
--- a/packages/client/lib/Client.ts
+++ b/packages/client/lib/Client.ts
@@ -48,6 +48,9 @@ export default class Client<
             case provider instanceof Swap: {
                 this.swap = provider as SwapType;
                 this.connectWallet(this.swap);
+                if (this.nft) {
+                    this.nft.setWallet(this.wallet);
+                }
                 this.connectChain();
                 break;
             }
@@ -55,6 +58,9 @@ export default class Client<
             case provider instanceof Nft: {
                 this._nft = provider as NftType;
                 this.connectWallet(this.nft);
+                if (this.swap) {
+                    this.swap.setWallet(this.wallet);
+                }
                 this.connectChain();
                 break;
             }


### PR DESCRIPTION
Bug:
When connect method is called with the Swap provider, the wallet gets updated to the wallet instance in the swap provider, but the wallet instance in the NFT provider isn't changed and vice-versa, which can lead to unexpected behaviors.

Fix:
Update the wallet instance in NFT when swap is changed and vise-versa